### PR TITLE
Add GPX elevation plotter tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,10 @@ Please note that the tools developed as part of the Traffic Signal Kit are inten
 
 Feedback, suggestions, bug reports, and contributions are welcome! If you have any ideas for new tools, improvements to existing tools, or general feedback about the project, feel free to open an issue, submit a pull request on GitHub or [fill out this feedback survey](https://forms.gle/eWchSuYdDwG6MsTx9).
 
+## GPX Elevation Plotter
+
+The GPX Elevation Plotter converts GPX files into an elevation profile. Paste GPX text into the tool and view a chart of elevation versus distance to analyze climbs and descents along your track.
+
 ## License
 
 The Traffic Signal Kit project is licensed under the [MIT License](LICENSE). Feel free to use, modify, and distribute the code for educational or personal projects. Refer to the LICENSE file for more information.

--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -154,6 +154,7 @@ export default {
         { title: "Time Space Visualizer", path: "/gpx" },
         { title: "GPX & Phase Plotter", path: "/gpx-phase-plotter" },
         { title: "GPX Mapper", path: "/gpx-mapper" },
+        { title: "GPX Elevation", path: "/gpx-elevation" },
       ],
       MiscTools: [
         { title: "Split Calculator", path: "/split-calculator" },

--- a/src/components/ProcessGPXElevation.vue
+++ b/src/components/ProcessGPXElevation.vue
@@ -1,0 +1,38 @@
+<template>
+  <div class="grow-wrap">
+    <InputBox v-model="inputData" :defaultText="gpxTextboxDefaultText" />
+  </div>
+  <br />
+  <v-btn color="primary" @click="btnPlot">Plot</v-btn>
+  <v-btn color="info" @click="resetZoom">Reset Zoom</v-btn>
+  <br />
+  <canvas ref="scatterPlotCanvas"></canvas>
+</template>
+
+<script>
+import InputBox from "./foundational/InputBox.vue";
+import processElevation from "../mixins/processElevation";
+
+export default {
+  mixins: [processElevation],
+  components: { InputBox },
+  data() {
+    return {
+      gpxTextboxDefaultText: "Paste in GPX file in XML format",
+      inputData: ""
+    };
+  },
+  methods: {
+    btnPlot() {
+      const pts = this.processGPXElevation(this.inputData);
+      this.renderElevationChart(pts);
+    }
+  }
+};
+</script>
+
+<style scoped>
+.grow-wrap > textarea {
+  height: 200px;
+}
+</style>

--- a/src/mixins/processElevation.js
+++ b/src/mixins/processElevation.js
@@ -1,0 +1,94 @@
+import gpxParser from 'gpxparser'
+import { Chart, Colors } from 'chart.js'
+import zoomPlugin from 'chartjs-plugin-zoom'
+Chart.register(zoomPlugin)
+Chart.register(Colors)
+
+export default {
+  data() {
+    return {}
+  },
+  methods: {
+    earthDistance(point1, point2, miles = true) {
+      const R = 6371
+      const [lat1, lon1] = point1
+      const [lat2, lon2] = point2
+      const dLat = ((lat2 - lat1) * Math.PI) / 180
+      const dLon = ((lon2 - lon1) * Math.PI) / 180
+      const a =
+        Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+        Math.cos((lat1 * Math.PI) / 180) *
+          Math.cos((lat2 * Math.PI) / 180) *
+          Math.sin(dLon / 2) *
+          Math.sin(dLon / 2)
+      const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a))
+      const distance = R * c
+      if (miles) {
+        return distance * 0.621371
+      } else {
+        return distance * 0.621371 * 5280
+      }
+    },
+    processGPXElevation(gpxText) {
+      const gpx = new gpxParser()
+      gpx.parse(gpxText)
+      if (!gpx.tracks || gpx.tracks.length === 0) {
+        return []
+      }
+      const pts = gpx.tracks[0].points
+      const dataset = []
+      let cumDist = 0
+      for (let i = 0; i < pts.length; i++) {
+        if (i > 0) {
+          const p1 = [pts[i - 1].lat, pts[i - 1].lon]
+          const p2 = [pts[i].lat, pts[i].lon]
+          cumDist += this.earthDistance(p1, p2, false)
+        }
+        const eleFt = pts[i].ele ? pts[i].ele * 3.28084 : 0
+        dataset.push({ x: cumDist, y: eleFt })
+      }
+      return dataset
+    },
+    renderElevationChart(dataset) {
+      const ctx = this.$refs.scatterPlotCanvas.getContext('2d')
+      const data = {
+        datasets: [
+          {
+            label: 'Elevation',
+            data,
+            borderColor: 'rgba(30, 139, 195, 1)',
+            backgroundColor: 'rgba(30, 139, 195, 0.5)',
+            showLine: true,
+            fill: false,
+            pointRadius: 2
+          }
+        ]
+      }
+      const options = {
+        scales: {
+          x: { type: 'linear', position: 'bottom', title: { display: true, text: 'Distance (ft)' } },
+          y: { type: 'linear', position: 'left', title: { display: true, text: 'Elevation (ft)' } }
+        },
+        plugins: {
+          zoom: {
+            zoom: {
+              wheel: { enabled: true },
+              pinch: { enabled: true },
+              drag: { enabled: true },
+              mode: 'xy'
+            }
+          }
+        }
+      }
+      if (this.elevationChart) {
+        this.elevationChart.destroy()
+      }
+      this.elevationChart = new Chart(ctx, { type: 'scatter', data, options })
+    },
+    resetZoom() {
+      if (this.elevationChart && this.elevationChart.resetZoom) {
+        this.elevationChart.resetZoom()
+      }
+    }
+  }
+}

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -10,6 +10,7 @@ import HighResPhasePlotter from '../views/HighResPhasePlotter'
 import TrafficSim from '../views/TrafficSim'
 import GPXPhasePlotter from '../views/GPXPhasePlotter'
 import GPXMapper from '../views/MapGPXPlotter'
+import GPXElevation from '../views/GPXElevation'
 import HighResDetectors from '../views/HighResDetectors'
 import PracticeExam from '../views/PracticeExam'
 
@@ -70,6 +71,11 @@ const routes = [
         path: '/gpx-mapper',
         name: 'gpxMapper',
         component: GPXMapper,
+    },
+    {
+        path: '/gpx-elevation',
+        name: 'gpxElevation',
+        component: GPXElevation,
     },
     {
         path: '/detectorRLR',

--- a/src/views/GPXElevation.vue
+++ b/src/views/GPXElevation.vue
@@ -1,0 +1,38 @@
+<template>
+  <div>
+    &nbsp;
+    <h1 class="h1-center-text">GPX Elevation Plotter</h1>
+    <div class="left-justify-text">
+      <v-expansion-panels v-model="panel" multiple>
+        <v-expansion-panel title="About: GPX Elevation Plotter" value="about">
+          <v-expansion-panel-text>
+            Paste GPX data and view the elevation profile over distance.
+          </v-expansion-panel-text>
+        </v-expansion-panel>
+      </v-expansion-panels>
+    </div>
+    <br />
+    <ProcessGPXElevation />
+  </div>
+</template>
+
+<script>
+import ProcessGPXElevation from "../components/ProcessGPXElevation.vue";
+export default {
+  name: "GPXElevation",
+  components: { ProcessGPXElevation },
+  data() {
+    return { panel: [] };
+  },
+  methods: {
+    all() {
+      this.panel = ["about"];
+    },
+    none() {
+      this.panel = [];
+    }
+  }
+};
+</script>
+
+<style scoped></style>


### PR DESCRIPTION
## Summary
- implement `processElevation` mixin for GPX elevation profiles
- create `ProcessGPXElevation` component
- add `GPXElevation` view
- register new route and menu link
- document the elevation plotter in README

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858925b9ccc832ba83b0beb80a45db3