### PR TITLE
Fix elevation chart dataset argument

### DIFF
--- a/src/mixins/processElevation.js
+++ b/src/mixins/processElevation.js
@@ -57,7 +57,7 @@ export default {
         datasets: [
           {
             label: 'Elevation',
-            data,
+            data: dataset,
             borderColor: 'rgba(30, 139, 195, 1)',
             backgroundColor: 'rgba(30, 139, 195, 0.5)',
             showLine: true,


### PR DESCRIPTION
## Summary
- use `dataset` argument when rendering elevation chart

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6859603832d0832ba0049d112be18a4c