### PR TITLE
Add lat/lon to elevation dataset points

### DIFF
--- a/src/mixins/processElevation.js
+++ b/src/mixins/processElevation.js
@@ -47,7 +47,12 @@ export default {
           cumDist += this.earthDistance(p1, p2, false)
         }
         const eleFt = pts[i].ele ? pts[i].ele * 3.28084 : 0
-        dataset.push({ x: cumDist, y: eleFt })
+        dataset.push({
+          x: cumDist,
+          y: eleFt,
+          lat: pts[i].lat,
+          lon: pts[i].lon
+        })
       }
       return dataset
     },


### PR DESCRIPTION
## Summary
- include `lat` and `lon` when processing elevation data so each entry has the original coordinates

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6859ed1cb0c8832b82b88b8050848f86