### PR TITLE
Show hovered lat/lon in elevation view

### DIFF
--- a/src/components/ProcessGPXElevation.vue
+++ b/src/components/ProcessGPXElevation.vue
@@ -7,6 +7,25 @@
   <v-btn color="info" @click="resetZoom">Reset Zoom</v-btn>
   <br />
   <canvas ref="scatterPlotCanvas"></canvas>
+  <br />
+  <table v-if="hoveredPoint">
+    <thead>
+      <tr>
+        <th>Distance (ft)</th>
+        <th>Elevation (ft)</th>
+        <th>Latitude</th>
+        <th>Longitude</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>{{ hoveredPoint.distance.toFixed(1) }}</td>
+        <td>{{ hoveredPoint.elevation.toFixed(1) }}</td>
+        <td>{{ hoveredPoint.lat.toFixed(5) }}</td>
+        <td>{{ hoveredPoint.lon.toFixed(5) }}</td>
+      </tr>
+    </tbody>
+  </table>
 </template>
 
 <script>

--- a/src/mixins/processElevation.js
+++ b/src/mixins/processElevation.js
@@ -8,7 +8,9 @@ Chart.register(Colors)
 
 export default {
   data() {
-    return {}
+    return {
+      hoveredPoint: null
+    }
   },
   methods: {
     earthDistance(point1, point2, miles = true) {
@@ -75,6 +77,19 @@ export default {
         scales: {
           x: { type: 'linear', position: 'bottom', title: { display: true, text: 'Distance (ft)' } },
           y: { type: 'linear', position: 'left', title: { display: true, text: 'Elevation (ft)' } }
+        },
+        onHover: (event, activeElements, chart) => {
+          if (activeElements.length) {
+            const raw = activeElements[0].element.$context.raw
+            this.hoveredPoint = {
+              distance: raw.x,
+              elevation: raw.y,
+              lat: raw.lat,
+              lon: raw.lon
+            }
+          } else {
+            this.hoveredPoint = null
+          }
         },
         plugins: {
           tooltip: {


### PR DESCRIPTION
## Summary
- capture the hovered point in the GPX elevation mixin
- show hovered distance, elevation, latitude and longitude in a table below the chart

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685ab828d878832bb7a0f5b376f63ac3