### PR TITLE
Add Preemption Event Plotter (enumerations 101–119)

### DIFF
--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -131,6 +131,7 @@ export default {
       tools: [
         { title: "Split History", path: "/split-history" },
         { title: "Red Light Runners", path: "/detectorRLR" },
+        { title: "Preemption Plotter", path: "/preemption-plotter" },
         { title: "Phase Plotter", path: "/phase-plotter" },
         { title: "High Res. Explainer", path: "/explainer" },
         { title: "Time Space Visualizer", path: "/gpx" },
@@ -147,6 +148,7 @@ export default {
       TSdataTools: [
         { title: "Split History", path: "/split-history" },
         { title: "Red Light Runners", path: "/detectorRLR" },
+        { title: "Preemption Plotter", path: "/preemption-plotter" },
         { title: "Phase Plotter", path: "/phase-plotter" },
         { title: "High Resolution Explainer", path: "/explainer" },
       ],

--- a/src/components/ProcessPreemptionEvents.vue
+++ b/src/components/ProcessPreemptionEvents.vue
@@ -1,0 +1,102 @@
+<template>
+  <div>
+    <div class="grow-wrap">
+      <InputBox v-model="inputData" :defaultText="textboxDefaultText" />
+    </div>
+    <div>
+      <v-btn @click="processPreemptionEvents" color="primary">
+        Process Preemption Events
+      </v-btn>
+    </div>
+  </div>
+</template>
+
+<script>
+import InputBox from "./foundational/InputBox.vue";
+import convertTime from "../mixins/convertTime";
+import enumerationObj from "../data/enumerations.json";
+
+export default {
+  mixins: [convertTime],
+  components: {
+    InputBox,
+  },
+  data() {
+    return {
+      inputData: "",
+      textboxDefaultText:
+        "Paste in High-Resolution Traffic Signal Data as CSV text (timestamp, enumeration, channel)",
+    };
+  },
+  methods: {
+    getEventDescriptor(eventCode) {
+      const match = enumerationObj.find(
+        (item) => parseInt(item.eventCode, 10) === eventCode
+      );
+      return match ? match.eventDescriptor.trim() : `Event ${eventCode}`;
+    },
+    processPreemptionEvents() {
+      const lines = this.inputData.split("\n");
+      const events = [];
+
+      lines.forEach((line) => {
+        const trimmedLine = line.trim();
+        if (!trimmedLine) {
+          return;
+        }
+        const [timestamp, eventCodeRaw, parameterRaw] = trimmedLine
+          .split(",")
+          .map((value) => value.trim());
+
+        const eventCode = parseInt(eventCodeRaw, 10);
+        if (Number.isNaN(eventCode) || eventCode < 101 || eventCode > 119) {
+          return;
+        }
+
+        const timestampInfo = this.convertTimestamp(timestamp);
+        if (!timestampInfo || Number.isNaN(timestampInfo.MillisecFromEpoch)) {
+          return;
+        }
+
+        events.push({
+          timestampISO: timestampInfo.iso,
+          timestampMs: timestampInfo.MillisecFromEpoch,
+          humanReadable: timestampInfo.humanReadable,
+          eventCode,
+          eventDescriptor: this.getEventDescriptor(eventCode),
+          parameterCode: parameterRaw ? parseInt(parameterRaw, 10) : null,
+        });
+      });
+
+      events.sort((a, b) => a.timestampMs - b.timestampMs);
+      this.$emit("preemptionEvents", events);
+    },
+  },
+};
+</script>
+
+<style scoped>
+.grow-wrap {
+  display: grid;
+}
+
+.grow-wrap::after {
+  content: attr(data-replicated-value) " ";
+  white-space: pre-wrap;
+  visibility: hidden;
+}
+
+.grow-wrap > textarea {
+  resize: none;
+  overflow: hidden;
+  overflow-y: scroll;
+}
+
+.grow-wrap > textarea,
+.grow-wrap::after {
+  border: 1px solid black;
+  padding: 0.5rem;
+  font: inherit;
+  grid-area: 1 / 1 / 2 / 2;
+}
+</style>

--- a/src/components/foundational/PlotPreemptionTimeSeries.vue
+++ b/src/components/foundational/PlotPreemptionTimeSeries.vue
@@ -1,0 +1,135 @@
+<template>
+  <br />
+  <v-btn @click="resetZoom">Reset Zoom</v-btn>
+  <br />
+  <Scatter
+    :data="chartData"
+    :options="chartOptions"
+    ref="scatterChart"
+  ></Scatter>
+</template>
+
+<script>
+import { Scatter } from "vue-chartjs";
+import zoom from "chartjs-plugin-zoom";
+import { Chart as ChartJS, Title, Tooltip, Legend, PointElement, LinearScale } from "chart.js";
+
+ChartJS.register(Title, Tooltip, Legend, PointElement, LinearScale, zoom);
+
+export default {
+  components: { Scatter },
+  props: {
+    plotData: {
+      type: Array,
+      required: true,
+    },
+  },
+  computed: {
+    baseTimeMs() {
+      return this.plotData.length > 0 ? this.plotData[0].timestampMs : 0;
+    },
+    eventLookup() {
+      return this.plotData.reduce((lookup, item) => {
+        lookup[item.eventCode] = item.eventDescriptor;
+        return lookup;
+      }, {});
+    },
+    chartData() {
+      if (!this.plotData.length) {
+        return {
+          datasets: [
+            {
+              label: "Preemption Events",
+              data: [],
+              borderColor: "#009688",
+              backgroundColor: "#009688",
+            },
+          ],
+        };
+      }
+
+      return {
+        datasets: [
+          {
+            label: "Preemption Events",
+            data: this.plotData.map((event) => ({
+              x: (event.timestampMs - this.baseTimeMs) / 1000,
+              y: event.eventCode,
+              event,
+            })),
+            borderColor: "#009688",
+            backgroundColor: "#009688",
+            pointRadius: 4,
+          },
+        ],
+      };
+    },
+    chartOptions() {
+      return {
+        responsive: true,
+        plugins: {
+          legend: {
+            display: true,
+          },
+          tooltip: {
+            callbacks: {
+              label: (context) => {
+                const event = context.raw?.event;
+                if (!event) {
+                  return `${context.parsed.y}`;
+                }
+                return [
+                  `${event.eventDescriptor} (Code ${event.eventCode})`,
+                  `Channel: ${event.parameterCode ?? "N/A"}`,
+                  `Time: ${event.humanReadable ?? event.timestampISO}`,
+                ];
+              },
+            },
+          },
+          zoom: {
+            zoom: {
+              wheel: {
+                enabled: true,
+              },
+              pinch: {
+                enabled: true,
+              },
+              mode: "xy",
+            },
+            pan: {
+              enabled: true,
+              mode: "xy",
+            },
+          },
+        },
+        scales: {
+          x: {
+            type: "linear",
+            position: "bottom",
+            title: {
+              display: true,
+              text: "Seconds from first preemption event",
+            },
+          },
+          y: {
+            type: "linear",
+            title: {
+              display: true,
+              text: "Preemption Event",
+            },
+            ticks: {
+              stepSize: 1,
+              callback: (value) => this.eventLookup[value] || value,
+            },
+          },
+        },
+      };
+    },
+  },
+  methods: {
+    resetZoom() {
+      this.$refs.scatterChart.chart.resetZoom();
+    },
+  },
+};
+</script>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -13,6 +13,7 @@ import GPXMapper from '../views/MapGPXPlotter'
 import GPXElevation from '../views/GPXElevation'
 import HighResDetectors from '../views/HighResDetectors'
 import PracticeExam from '../views/PracticeExam'
+import HighResPreemptionPlotter from '../views/HighResPreemptionPlotter'
 
 
 
@@ -81,6 +82,11 @@ const routes = [
         path: '/detectorRLR',
         name: 'detectorRLR',
         component: HighResDetectors,
+    },
+    {
+        path: '/preemption-plotter',
+        name: 'preemptionPlotter',
+        component: HighResPreemptionPlotter,
     },
     {
         path: '/PracticeExam',

--- a/src/views/About.vue
+++ b/src/views/About.vue
@@ -55,6 +55,14 @@ export default {
         },
         {
           image:
+            "https://trafficsignalkit.s3.us-east-2.amazonaws.com/Photos/trafficsignalkit.com-high-resolution-controller-data-explainer-ATSPM.png",
+          title: "Preemption Event Plotter",
+          description: "Plot preemption (101-119) enumeration events over time",
+          link: "/preemption-plotter",
+          topics: ["Controller Data", "Enumerations", "Preemption"],
+        },
+        {
+          image:
             "https://trafficsignalkit.s3.us-east-2.amazonaws.com/Photos/trafficsignalkit.com+-+split+history+phase+termination+table.png",
           title: "High Resolution Split History",
           description: "Calculate Phase Durations from High Resolution Data",

--- a/src/views/HighResPreemptionPlotter.vue
+++ b/src/views/HighResPreemptionPlotter.vue
@@ -1,0 +1,79 @@
+<template>
+  <div>
+    &nbsp;
+    <h1 class="h1-center-text">Preemption Event Plotter</h1>
+
+    <div class="left-justify-text">
+      <v-expansion-panels v-model="panel" multiple>
+        <v-expansion-panel title="About: Preemption Events" value="about">
+          <v-expansion-panel-text>
+            Preemption events (enumerations 101-119) capture the sequence of
+            controller actions when an emergency vehicle, railroad, or other
+            priority request forces the signal out of its normal operation. This
+            tool filters the preemption-related enumerations from high
+            resolution controller data and plots them on a time series so you
+            can see when each stage of the preemption occurred.
+          </v-expansion-panel-text>
+        </v-expansion-panel>
+
+        <v-expansion-panel title="What This Tool Shows" value="details">
+          <v-expansion-panel-text>
+            <ul>
+              <li>Timeline of preemption event codes 101-119</li>
+              <li>Event labels for each preemption stage</li>
+              <li>Channel values captured with each event</li>
+            </ul>
+          </v-expansion-panel-text>
+        </v-expansion-panel>
+
+        <v-expansion-panel title="Example: Using This Tool" value="example">
+          <v-expansion-panel-text>
+            Paste high resolution controller data as CSV lines in the format:
+            <pre>
+16764339605, 101, 1
+16764339625, 102, 1
+16764339645, 105, 1
+16764339705, 111, 1
+            </pre>
+            Click <b>Process Preemption Events</b> to plot the preemption event
+            timeline.
+          </v-expansion-panel-text>
+        </v-expansion-panel>
+      </v-expansion-panels>
+    </div>
+
+    <br />
+    <ProcessPreemptionEvents
+      @preemptionEvents="storePreemptionEvents"
+    ></ProcessPreemptionEvents>
+    <PlotPreemptionTimeSeries
+      :plotData="preemptionEvents"
+    ></PlotPreemptionTimeSeries>
+  </div>
+</template>
+
+<script>
+import ProcessPreemptionEvents from "../components/ProcessPreemptionEvents.vue";
+import PlotPreemptionTimeSeries from "../components/foundational/PlotPreemptionTimeSeries.vue";
+
+export default {
+  name: "PreemptionPlotter",
+  components: {
+    ProcessPreemptionEvents,
+    PlotPreemptionTimeSeries,
+  },
+  data() {
+    return {
+      panel: [],
+      preemptionEvents: [],
+    };
+  },
+  methods: {
+    storePreemptionEvents(events) {
+      this.preemptionEvents = events;
+    },
+  },
+};
+</script>
+
+<style scoped></style>


### PR DESCRIPTION
### Motivation
- Provide a new tool that detects and visualizes preemption-related enumerations (101–119) from high-resolution controller logs. 
- Give users a time-series view to inspect the sequence and timing of preemption stages for debugging and analysis. 
- Integrate the tool into the existing navigation and main page so it is discoverable alongside other controller-data tools. 

### Description
- Added a preemption processing component `src/components/ProcessPreemptionEvents.vue` that filters CSV lines and extracts events with enumeration codes `101`–`119` using the existing `convertTimestamp` mixin and `enumerations.json`. 
- Added a scatter time-series plot component `src/components/foundational/PlotPreemptionTimeSeries.vue` that renders preemption events with `vue-chartjs` and `chartjs-plugin-zoom` and shows descriptive tooltips. 
- Added a view `src/views/HighResPreemptionPlotter.vue` and wired the route in `src/router/index.js`, plus added navigation/menu entries in `src/components/Header.vue` and a card on the main page in `src/views/About.vue`. 

### Testing
- Started the dev server with `npm run dev -- --host 0.0.0.0 --port 4173`, which launched a Vite process, but the UI endpoint was not reachable at `127.0.0.1:4173` (connection refused). 
- Attempted automated browser verification with Playwright to capture a screenshot of `/preemption-plotter`, but navigation failed with `net::ERR_EMPTY_RESPONSE` and the screenshot could not be obtained. 
- `curl` to `http://0.0.0.0:4173` returned `403 Forbidden`, indicating the server process responded but the route access attempt did not succeed. 
- No unit tests were added or executed as part of this change; code was committed successfully (`Add preemption event plotter tool`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6951f5a648c8832bb80d003a6d121ce6)