### PR TITLE
Preemption plot: use timestamp x-axis and display all enumerations

### DIFF
--- a/src/components/ProcessPreemptionEvents.vue
+++ b/src/components/ProcessPreemptionEvents.vue
@@ -49,7 +49,7 @@ export default {
           .map((value) => value.trim());
 
         const eventCode = parseInt(eventCodeRaw, 10);
-        if (Number.isNaN(eventCode) || eventCode < 101 || eventCode > 119) {
+        if (Number.isNaN(eventCode)) {
           return;
         }
 


### PR DESCRIPTION
### Motivation
- Present every enumeration on the preemption time series plot with human-readable labels to support full high-resolution controller datasets.  
- Use real timestamps on the x-axis so users can zoom and pan in time rather than relative seconds.  
- Let the preemption processor accept all event codes so non-preemption enumerations can also be visualized.  
- Preserve interactive zoom/pan behavior while improving axis labeling and enumeration rendering.  

### Description
- Updated `PlotPreemptionTimeSeries.vue` to import the full enumeration list from `src/data/enumerations.json` and register `CategoryScale` with `ChartJS`.  
- Converted the x-values to use raw event timestamps (`timestampMs`) and added a tick callback to format x-axis values as localized date/time strings.  
- Switched the y-scale to `type: 'category'` and populated it with `enumerationLabels` so each enumeration is shown as a labeled row on the plot.  
- Modified `ProcessPreemptionEvents.vue` to allow all parsed event codes (removed the previous `101-119` filter) so the processor emits events for the full enumeration set.  

### Testing
- Attempted to start the dev server (`vite`) and exercise the UI with a Playwright script, but the application port (`127.0.0.1:4173`) did not accept connections so the UI test could not complete (failed).  
- No automated unit or integration test suite was run as part of this change.  
- Manual verification steps remain: load the Preemption Plotter page, paste high-resolution CSV into the input box, click `Process Preemption Events`, and use mouse wheel/pan to confirm zoom/pan and labels.  
- If requested, a follow-up will run automated UI tests once the dev server environment is reachable.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69520edfa198832ba42998ae3dd3efbf)