### PR TITLE
Add aria-labels to footer icon buttons

### DIFF
--- a/src/components/Footer.vue
+++ b/src/components/Footer.vue
@@ -10,6 +10,7 @@
         :key="icon.id"
         class="mx-4"
         :icon="icon.icon"
+        :aria-label="icon.label"
         variant="plain"
         size="small"
         :href="icon.link"
@@ -41,11 +42,13 @@ export default {
       {
         id: 1,
         icon: "mdi-github",
+        label: "GitHub repository",
         link: "https://github.com/redmond2742/TrafficSignalKit",
       },
       {
         id: 2,
         icon: "mdi-linkedin",
+        label: "LinkedIn profile",
         link: "https://www.linkedin.com/in/matt-redmond-00700a36/",
       },
     ],


### PR DESCRIPTION
### Motivation
- Improve accessibility by making icon-only buttons in the footer identifiable to assistive technologies.
- Ensure the existing `v-btn` icon links convey their purpose to screen readers.

### Description
- Added a `label` property to each entry in the `footerIcons` array in `src/components/Footer.vue`.
- Bound the label to the button via `:aria-label="icon.label"` on the `v-btn` rendered inside the footer.
- Updated the two footer icons to include `label` values (`"GitHub repository"` and `"LinkedIn profile"`).

### Testing
- No automated tests were run for this change.
- The change is limited to a template/data update in `src/components/Footer.vue` and should not affect runtime logic.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952173ab354832bba7877682859d5c2)