### PR TITLE
Replace nested router-links with routed `v-list-item` and add active/focus styles in header

### DIFF
--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -20,12 +20,15 @@
         </template>
 
         <v-list>
-          <v-list-item v-for="(item, index) in TSdataTools" :key="index">
-            <v-list-item-title
-              ><router-link :to="item.path"
-                >{{ item.title }}
-              </router-link></v-list-item-title
-            >
+          <v-list-item
+            v-for="(item, index) in TSdataTools"
+            :key="index"
+            :to="item.path"
+            link
+            active-class="nav-item-active"
+            class="nav-list-item"
+          >
+            <v-list-item-title>{{ item.title }}</v-list-item-title>
           </v-list-item>
         </v-list>
       </v-menu>
@@ -37,12 +40,15 @@
         </template>
 
         <v-list>
-          <v-list-item v-for="(item, index) in TSgpxTools" :key="index">
-            <v-list-item-title
-              ><router-link :to="item.path"
-                >{{ item.title }}
-              </router-link></v-list-item-title
-            >
+          <v-list-item
+            v-for="(item, index) in TSgpxTools"
+            :key="index"
+            :to="item.path"
+            link
+            active-class="nav-item-active"
+            class="nav-list-item"
+          >
+            <v-list-item-title>{{ item.title }}</v-list-item-title>
           </v-list-item>
         </v-list>
       </v-menu>
@@ -54,12 +60,15 @@
         </template>
 
         <v-list>
-          <v-list-item v-for="(item, index) in MiscTools" :key="index">
-            <v-list-item-title
-              ><router-link :to="item.path"
-                >{{ item.title }}
-              </router-link></v-list-item-title
-            >
+          <v-list-item
+            v-for="(item, index) in MiscTools"
+            :key="index"
+            :to="item.path"
+            link
+            active-class="nav-item-active"
+            class="nav-list-item"
+          >
+            <v-list-item-title>{{ item.title }}</v-list-item-title>
           </v-list-item>
         </v-list>
       </v-menu>
@@ -113,6 +122,9 @@
         v-for="(item, index) in tools"
         :key="index"
         :to="item.path"
+        link
+        active-class="nav-item-active"
+        class="nav-list-item"
         @click="drawer = false"
       >
         <v-list-item-title>{{ item.title }}</v-list-item-title>
@@ -214,5 +226,13 @@ a {
 .title-justify {
   justify-content: flex-start;
   margin-left: 10px;
+}
+:deep(.nav-item-active) {
+  color: rgb(var(--v-theme-primary));
+  font-weight: 600;
+}
+:deep(.nav-list-item:focus-visible) {
+  outline: 2px solid rgb(var(--v-theme-primary));
+  outline-offset: 2px;
 }
 </style>


### PR DESCRIPTION
### Motivation

- Unify the navigation interaction pattern by using Vuetify's routed `v-list-item` instead of nested `router-link` elements across header menus and the mobile drawer. 
- Provide a consistent active/selected visual state for menu entries so the current route is clearly indicated. 
- Improve keyboard accessibility by making the focus state visible for list items. 

### Description

- Replaced `v-list-item-title` + nested `<router-link>` with `v-list-item` configured with `:to`, `link`, and `active-class="nav-item-active"` for `TSdataTools`, `TSgpxTools`, and `MiscTools` lists. 
- Applied the same routed configuration (`link`, `:to`, `active-class="nav-item-active"`) and `class="nav-list-item"` to the mobile drawer items so desktop menus and the drawer share one interaction pattern. 
- Added scoped styles using `:deep(.nav-item-active)` to style the active item with the theme primary color and increased weight, and `:deep(.nav-list-item:focus-visible)` to show a visible outline for keyboard focus. 

### Testing

- Attempted to start the dev server with `npm run dev` and run a Playwright script to capture a screenshot, but the browser checks failed because the dev server was not reachable. 
- No automated unit tests were executed for this UI-only change. 
- The modified file `src/components/Header.vue` was linted/compiled locally as part of development steps and committed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69521701653c832b95131ca1207b7859)