### PR TITLE
Rename Preemption Plotter page to "Timeseries Plot All Enumerations"

### DIFF
--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -143,7 +143,7 @@ export default {
       tools: [
         { title: "Split History", path: "/split-history" },
         { title: "Red Light Runners", path: "/detectorRLR" },
-        { title: "Preemption Plotter", path: "/preemption-plotter" },
+        { title: "Timeseries Plot All Enumerations", path: "/preemption-plotter" },
         { title: "Phase Plotter", path: "/phase-plotter" },
         { title: "High Res. Explainer", path: "/explainer" },
         { title: "Time Space Visualizer", path: "/gpx" },
@@ -160,7 +160,7 @@ export default {
       TSdataTools: [
         { title: "Split History", path: "/split-history" },
         { title: "Red Light Runners", path: "/detectorRLR" },
-        { title: "Preemption Plotter", path: "/preemption-plotter" },
+        { title: "Timeseries Plot All Enumerations", path: "/preemption-plotter" },
         { title: "Phase Plotter", path: "/phase-plotter" },
         { title: "High Resolution Explainer", path: "/explainer" },
       ],

--- a/src/views/About.vue
+++ b/src/views/About.vue
@@ -56,7 +56,7 @@ export default {
         {
           image:
             "https://trafficsignalkit.s3.us-east-2.amazonaws.com/Photos/trafficsignalkit.com-high-resolution-controller-data-explainer-ATSPM.png",
-          title: "Preemption Event Plotter",
+          title: "Timeseries Plot All Enumerations",
           description: "Plot preemption (101-119) enumeration events over time",
           link: "/preemption-plotter",
           topics: ["Controller Data", "Enumerations", "Preemption"],

--- a/src/views/HighResPreemptionPlotter.vue
+++ b/src/views/HighResPreemptionPlotter.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     &nbsp;
-    <h1 class="h1-center-text">Preemption Event Plotter</h1>
+    <h1 class="h1-center-text">Timeseries Plot All Enumerations</h1>
 
     <div class="left-justify-text">
       <v-expansion-panels v-model="panel" multiple>


### PR DESCRIPTION
### Motivation
- Make the page title more descriptive by indicating the tool plots timeseries for enumerations.
- Ensure the navigation and About page use a consistent, clearer label for the preemption plot tool.
- Improve discoverability and reduce ambiguity about what the tool displays.

### Description
- Change the page heading in `src/views/HighResPreemptionPlotter.vue` to `Timeseries Plot All Enumerations`.
- Update navigation labels in `src/components/Header.vue` (tools lists) to show `Timeseries Plot All Enumerations` while keeping the path `/preemption-plotter`.
- Update the `About` page entry in `src/views/About.vue` to the new title and retain the existing description and link.
- No route paths or runtime logic were modified; this is a UI/label change only.

### Testing
- Launched the dev server with `npm run dev -- --host 0.0.0.0 --port 4173`, and Vite started successfully.
- Executed a Playwright script to open `/preemption-plotter` and capture a screenshot, but the Chromium browser crashed and the screenshot attempt failed.
- No unit or integration test suites were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952194d8468832b93780cab1309afc6)