### PR TITLE
Make DisplayCard the single navigation target and add image alt text

### DIFF
--- a/src/components/foundational/DisplayCard.vue
+++ b/src/components/foundational/DisplayCard.vue
@@ -1,25 +1,23 @@
 <template>
-  <v-card class="mx-auto" max-width="500">
-    <router-link :to="link" class="no-decoration">
-      <v-img :src="image" height="200px"></v-img>
-      <v-card-title class="title">{{ title }}</v-card-title>
-      <v-card-text class="description">{{ description }}</v-card-text>
-      <v-card-actions class="centered-actions">
-        <v-btn text color="primary" @click="goToLink">Explore Tool</v-btn>
-      </v-card-actions>
-      <v-card-subtitle>
-        <v-chip-group column>
-          <v-chip
-            v-for="(topic, index) in topics"
-            :key="index"
-            class="ma-1"
-            small
-          >
-            {{ topic }}
-          </v-chip>
-        </v-chip-group>
-      </v-card-subtitle>
-    </router-link>
+  <v-card class="mx-auto" max-width="500" :to="link" link>
+    <v-img :src="image" height="200px" :alt="resolvedImageAlt"></v-img>
+    <v-card-title class="title">{{ title }}</v-card-title>
+    <v-card-text class="description">{{ description }}</v-card-text>
+    <v-card-actions class="centered-actions">
+      <span class="explore-text">Explore Tool</span>
+    </v-card-actions>
+    <v-card-subtitle>
+      <v-chip-group column>
+        <v-chip
+          v-for="(topic, index) in topics"
+          :key="index"
+          class="ma-1"
+          small
+        >
+          {{ topic }}
+        </v-chip>
+      </v-chip-group>
+    </v-card-subtitle>
   </v-card>
 </template>
 
@@ -43,15 +41,18 @@ export default {
       type: String,
       required: true,
     },
+    imageAlt: {
+      type: String,
+      default: "",
+    },
     topics: {
       type: Array,
       required: true,
     },
   },
-  methods: {
-    goToLink() {
-      this.$router.push(this.link);
-      //window.location.href = this.link;
+  computed: {
+    resolvedImageAlt() {
+      return this.imageAlt || this.title;
     },
   },
 };
@@ -67,10 +68,9 @@ export default {
   background-color: #f5f5f5;
 }
 
-.no-decoration {
-  text-decoration: none;
-  color: inherit;
-  display: block;
+.v-card:focus-visible {
+  outline: 2px solid #1976d2;
+  outline-offset: 2px;
 }
 
 .description {
@@ -94,6 +94,10 @@ export default {
 .centered-actions {
   display: flex;
   justify-content: center; /* Center horizontally */
+}
+.explore-text {
+  color: #1976d2;
+  font-weight: 500;
 }
 .title {
   word-wrap: wrap;

--- a/src/views/About.vue
+++ b/src/views/About.vue
@@ -23,6 +23,7 @@
           ><v-sheet class="ma-2 pa-2">
             <DisplayCard
               :image="post.image"
+              :image-alt="post.title"
               :title="post.title"
               :description="post.description"
               :link="post.link"


### PR DESCRIPTION
### Motivation
- Ensure each card has a single, clear interactive navigation target to improve accessibility and keyboard focus.
- Remove nested interactive elements (outer `router-link` + inner button) which created multiple navigation targets.
- Provide meaningful `alt` text for card images with a sensible default to improve accessibility.
- Make keyboard focus visible when a card is focused.

### Description
- Removed the outer `router-link` wrapper and applied `:to="link"` and `link` props directly to `v-card` so the card is the single navigation target.
- Added an `imageAlt` prop (default `""`) and a `resolvedImageAlt` computed property that falls back to `title`, then bound it to `v-img` via `:alt`.
- Replaced the clickable `v-btn` with a non-interactive `span.explore-text` to avoid nested interactive controls and styled it for visual affordance.
- Added `:focus-visible` styling on `.v-card` to show a clear outline when focused and added `.explore-text` styling.

### Testing
- Launched the Vite dev server with `npm run dev` which reported ready and served the app successfully.
- Verified the server responded with `HTTP 200` using `curl -I` against the root URL.
- Automated browser test using Playwright navigated to `/#/about` and captured a screenshot (`artifacts/display-card.png`) confirming the updated card rendering.
- All automated checks executed in the rollout succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69521a83d5d8832b84557bfcb3a91655)