### PR TITLE
Add Excel export for High Resolution Data Explainer table

### DIFF
--- a/src/components/CSVInput.vue
+++ b/src/components/CSVInput.vue
@@ -27,6 +27,15 @@
               placeholder="Filter by timestamp, enumeration or channel/phase"
               v-model="filter"
             />
+            <div class="table-actions">
+              <v-btn
+                color="secondary"
+                :disabled="!rowData.length"
+                @click="exportToExcel"
+              >
+                Export to Excel
+              </v-btn>
+            </div>
             <table>
               <thead>
                 <tr>
@@ -302,6 +311,44 @@ export default {
         console.log("number, not text");
       }
     },
+    exportToExcel() {
+      const rows = this.filteredRows.length ? this.filteredRows : this.rowData;
+      const header = ["Timestamp", "Enumeration", "Channel/Phase"];
+      const bodyRows = rows
+        .map((row) => {
+          return `
+            <tr>
+              <td>${row.timestamp}</td>
+              <td>${row.enumeration}</td>
+              <td>${row.channel}</td>
+            </tr>
+          `;
+        })
+        .join("");
+      const tableHtml = `
+        <table>
+          <thead>
+            <tr>
+              ${header.map((label) => `<th>${label}</th>`).join("")}
+            </tr>
+          </thead>
+          <tbody>
+            ${bodyRows}
+          </tbody>
+        </table>
+      `;
+      const blob = new Blob(["\ufeff", tableHtml], {
+        type: "application/vnd.ms-excel",
+      });
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = url;
+      link.download = "high-resolution-data-explainer.xls";
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      URL.revokeObjectURL(url);
+    },
   },
   computed: {
     filteredRows() {
@@ -401,6 +448,11 @@ select {
   border-radius: 4px;
   box-sizing: border-box;
   margin-top: 25px;
+}
+.table-actions {
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 12px;
 }
 dd {
   margin-left: 0;


### PR DESCRIPTION
### Motivation
- Provide users of the High Resolution Data Explainer a quick way to download the displayed table as an Excel-compatible file.
- Surface the export action alongside the existing table filter so it is easy to find and use.
- Ensure the export respects the current filter (so users can download only the visible rows).

### Description
- Added an `Export to Excel` button to `CSVInput.vue` and wired it to a new `exportToExcel` method.  
- Implemented `exportToExcel` to build an HTML table from `filteredRows` (falling back to `rowData`) and trigger a download as an `.xls` Blob.  
- Disabled the export button when there is no data and added `.table-actions` CSS to align the control with the table filter.  

### Testing
- Launched the dev server with `npm run dev` and Vite reported the site as ready (local and network URLs printed).  
- Attempted an automated UI check with Playwright to exercise the explainer page and capture a screenshot, but the Chromium run crashed in the environment and the Playwright script failed.  
- No unit tests were added or run for this UI change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69521aa8dd98832bb43f78c0fdb9f7db)