### PR TITLE
Fix CSV export to use text values instead of HTML

### DIFF
--- a/src/components/CSVInput.vue
+++ b/src/components/CSVInput.vue
@@ -314,36 +314,28 @@ export default {
     exportToExcel() {
       const rows = this.filteredRows.length ? this.filteredRows : this.rowData;
       const header = ["Timestamp", "Enumeration", "Channel/Phase"];
-      const bodyRows = rows
-        .map((row) => {
-          return `
-            <tr>
-              <td>${row.timestamp}</td>
-              <td>${row.enumeration}</td>
-              <td>${row.channel}</td>
-            </tr>
-          `;
-        })
-        .join("");
-      const tableHtml = `
-        <table>
-          <thead>
-            <tr>
-              ${header.map((label) => `<th>${label}</th>`).join("")}
-            </tr>
-          </thead>
-          <tbody>
-            ${bodyRows}
-          </tbody>
-        </table>
-      `;
-      const blob = new Blob(["\ufeff", tableHtml], {
-        type: "application/vnd.ms-excel",
+      const escapeCsvValue = (value) => {
+        const stringValue = `${value}`;
+        if (/[",\n\t]/.test(stringValue)) {
+          return `"${stringValue.replace(/"/g, '""')}"`;
+        }
+        return stringValue;
+      };
+      const bodyRows = rows.map((row) => [
+        row.timestamp,
+        row.enumeration,
+        row.channel,
+      ]);
+      const csvContent = [header, ...bodyRows]
+        .map((row) => row.map(escapeCsvValue).join(","))
+        .join("\n");
+      const blob = new Blob(["\ufeff", csvContent], {
+        type: "text/csv;charset=utf-8",
       });
       const url = URL.createObjectURL(blob);
       const link = document.createElement("a");
       link.href = url;
-      link.download = "high-resolution-data-explainer.xls";
+      link.download = "high-resolution-data-explainer.csv";
       document.body.appendChild(link);
       link.click();
       document.body.removeChild(link);


### PR DESCRIPTION
### Motivation
- The previous export produced an HTML table blob which embedded HTML tags in cells instead of plain text values.
- Consumers require a CSV file with the raw textual contents of each `<td>` cell for easy import into spreadsheets and data tools.

### Description
- Replace HTML table generation with CSV generation by serializing `header` and `rows` into `csvContent`.
- Add an `escapeCsvValue` helper to escape quotes, commas, and newlines according to CSV rules and map rows to arrays before joining.
- Create the download as a `Blob` with MIME `text/csv;charset=utf-8` and change the filename to `high-resolution-data-explainer.csv`.
- Preserve the existing row source logic (uses `filteredRows` when present, otherwise `rowData`).

### Testing
- No automated tests were run for this change.
- The change was committed locally and the modified file is `src/components/CSVInput.vue`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69521ff0c6b8832ba12827cdc6c2c42a)