### PR TITLE
Add reference tables for Enumerations 150 and 155 to Reference view

### DIFF
--- a/src/views/Reference.vue
+++ b/src/views/Reference.vue
@@ -72,6 +72,46 @@
         </v-table>
       </v-col>
     </v-row>
+
+    <v-row class="mt-8">
+      <v-col>
+        <h2>Enumeration 150 - Coord Cycle State Change</h2>
+        <v-table density="compact" class="mt-3">
+          <thead>
+            <tr>
+              <th class="text-left">Parameter</th>
+              <th class="text-left">Definition</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="state in coordCycleStates" :key="state.parameter">
+              <td>{{ state.parameter }}</td>
+              <td>{{ state.definition }}</td>
+            </tr>
+          </tbody>
+        </v-table>
+      </v-col>
+    </v-row>
+
+    <v-row class="mt-8">
+      <v-col>
+        <h2>Enumeration 155 - Unit Control Status Change</h2>
+        <v-table density="compact" class="mt-3">
+          <thead>
+            <tr>
+              <th class="text-left">Parameter</th>
+              <th class="text-left">Definition</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="status in unitControlStatuses" :key="status.parameter">
+              <td>{{ status.parameter }}</td>
+              <td>{{ status.definition }}</td>
+            </tr>
+          </tbody>
+        </v-table>
+      </v-col>
+    </v-row>
   </v-container>
 </template>
 
@@ -139,6 +179,28 @@ export default {
           description:
             "When the Controller Unit is operating in the coordinated mode and cycling diagnostics indicate that a serviceable call exists that has not been serviced for two cycles.",
         },
+      ],
+      coordCycleStates: [
+        { parameter: 0, definition: "Free" },
+        { parameter: 1, definition: "In Step" },
+        { parameter: 2, definition: "Transition - Add" },
+        { parameter: 3, definition: "Transition - Subtract" },
+        { parameter: 4, definition: "Transition - Dwell" },
+        { parameter: 5, definition: "Local Zero" },
+        { parameter: 6, definition: "Begin Pickup" },
+        { parameter: 7, definition: "Master Cycle Zero" },
+      ],
+      unitControlStatuses: [
+        { parameter: 1, definition: "Other" },
+        { parameter: 2, definition: "System Control" },
+        { parameter: 3, definition: "System Standby" },
+        { parameter: 4, definition: "Backup Mode" },
+        { parameter: 5, definition: "Manual" },
+        { parameter: 6, definition: "Timebase" },
+        { parameter: 7, definition: "Interconnect" },
+        { parameter: 8, definition: "Interconnect Backup" },
+        { parameter: 9, definition: "Remote Manual Control" },
+        { parameter: 10, definition: "Local Manual Control" },
       ],
     };
   },


### PR DESCRIPTION
### Motivation
- Provide quick lookup tables for NTCIP enumeration mappings used in events so users can see parameter-to-definition mappings in the Reference view.
- Improve documentation for Coordination Cycle State changes (Enumeration 150) and Unit Control Status changes (Enumeration 155).

### Description
- Updated `src/views/Reference.vue` to add two new sections with compact tables: "Enumeration 150 - Coord Cycle State Change" and "Enumeration 155 - Unit Control Status Change".
- Added `coordCycleStates` and `unitControlStatuses` data arrays and bound them to the new tables to render parameter/definition rows.
- Kept existing reference tables intact and followed the same table formatting and component patterns used elsewhere in the view.

### Testing
- Started the dev server with `npm run dev`, which launched the app and served the site successfully.
- Attempted to capture a screenshot of the `/reference` page using a Playwright script, but the headless browser crashed (`TargetClosedError` / SIGSEGV) so no screenshot was produced.
- No automated unit tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696962f98278832baabf858d481c3b42)