### PR TITLE
Improve detection timeseries plot usability

### DIFF
--- a/src/components/foundational/InputBox.vue
+++ b/src/components/foundational/InputBox.vue
@@ -1,10 +1,11 @@
 <template>
   <textarea
     type="text"
-    rows="20"
+    rows="10"
     v-model="inputData"
     @blur="emitInput"
     @focus="clearText"
+    class="input-box"
   />
 </template>
 
@@ -73,9 +74,10 @@ export default {
   grid-area: 1 / 1 / 2 / 2;
 }
 
-textarea {
-  overflow-y: scroll;
-  height: 100px;
+.input-box {
+  overflow-y: auto;
+  max-height: 220px;
+  min-height: 140px;
 }
 
 input[type="text"],


### PR DESCRIPTION
### Motivation
- Make the detection channel timeseries UI easier to use by adding a compact, scrollable mapping input, a sorting toggle between detection and phase alignment, and more intuitive zoom behavior.
- Ensure the high-resolution phase state overlay includes all phases present in the data (including phases not mapped to a detector). 
- Give users click-and-drag zooming on the time axis and a reset control that defaults to the time span of events shown.

### Description
- Replaced the radio-group alignment control with a `v-btn-toggle` and label, and reduced the mapping textarea height while making it scrollable via `.mapping-textarea` to avoid large page footprint. 
- Added computed properties `mappedPhaseCodes`, `extraPhases`, `mappedPhaseAxisLabels`, and `extraPhaseAxisLabels`, and changed `phaseAxisLabels`/`phaseLookup`/`phaseAxisLabelGroups` so all detected phase codes appear on the phase axis even when they are not mapped to detectors. 
- Updated phase dataset generation to fall back to unmapped phase labels when no mapped rows exist for a phase, and combined `plotData` and `phaseData` into a single `eventRange` used for the x-axis default min/max. 
- Enabled drag-to-zoom and x-only pan/zoom in the chart plugin and added a `Reset Zoom` button that calls `resetZoom`; lowered the `InputBox` textarea rows and added an `.input-box` style for a scrollable input area.

### Testing
- Started the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` and the server reported ready, which succeeded. 
- Verified the detection plot route returned a page by running `curl -I http://127.0.0.1:4173/detection-plotter` which returned `HTTP/1.1 200 OK`. 
- Ran a Playwright navigation script that opened `/detection-plotter` and saved a screenshot `artifacts/detection-plotter.png`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696c0db9f5ec832bb4a67dad0614ad21)