### PR TITLE
Update detection plotter event styles (on=blue, off=purple, fault=red X)

### DIFF
--- a/src/components/foundational/PlotDetectionTimeSeries.vue
+++ b/src/components/foundational/PlotDetectionTimeSeries.vue
@@ -437,9 +437,21 @@ export default {
               y: this.channelLookup[event.parameterCode] ?? `Channel ${event.parameterCode}`,
               event,
             })),
-            borderColor: "#1976d2",
-            backgroundColor: "#1976d2",
-            pointRadius: 4,
+            borderColor: this.plotData.map(
+              (event) => this.getDetectionEventStyle(event).color
+            ),
+            backgroundColor: this.plotData.map(
+              (event) => this.getDetectionEventStyle(event).color
+            ),
+            pointRadius: this.plotData.map(
+              (event) => this.getDetectionEventStyle(event).radius
+            ),
+            pointStyle: this.plotData.map(
+              (event) => this.getDetectionEventStyle(event).style
+            ),
+            pointHoverRadius: this.plotData.map(
+              (event) => this.getDetectionEventStyle(event).radius + 1
+            ),
           },
         ].concat(this.phaseDataset ? [this.phaseDataset] : []),
       };
@@ -542,6 +554,23 @@ export default {
     },
   },
   methods: {
+    getDetectionEventStyle(event) {
+      const descriptor = event?.eventDescriptor?.toLowerCase() ?? "";
+
+      if (descriptor.includes("fault") || descriptor.includes("failed")) {
+        return { color: "#e53935", style: "crossRot", radius: 6 };
+      }
+
+      if (descriptor.includes("detector on")) {
+        return { color: "#1e88e5", style: "circle", radius: 4 };
+      }
+
+      if (descriptor.includes("detector off")) {
+        return { color: "#8e24aa", style: "circle", radius: 4 };
+      }
+
+      return { color: "#546e7a", style: "circle", radius: 4 };
+    },
     formatPhaseAxisLabel(value) {
       if (value == null) {
         return "";


### PR DESCRIPTION
### Motivation
- Improve visual distinction of detector events in the detection channel timeseries by coloring on/off events and clearly highlighting faults.

### Description
- Added a helper method `getDetectionEventStyle` to compute per-event style (color, `pointStyle`, and radius) based on the event descriptor.
- Updated the detection events dataset in `src/components/foundational/PlotDetectionTimeSeries.vue` to supply per-point `borderColor`, `backgroundColor`, `pointRadius`, `pointStyle`, and `pointHoverRadius` arrays derived from `getDetectionEventStyle`.
- Event styling rules: detector on -> blue `#1e88e5`, detector off -> purple `#8e24aa`, faults/failed -> red `#e53935` with `crossRot` marker, and a grey default.

### Testing
- Started the dev server with `npm run dev -- --host 0.0.0.0 --port 4173`; server process was launched.
- Attempted an automated UI check with Playwright to capture a screenshot of `#/detection-plotter`, but Chromium crashed in this environment and the Playwright run failed.
- No unit tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696c56ea258c832b86ba28b4ffd3d39e)