### PR TITLE
Add delay estimator toggle, summary, cycle length column, and home card

### DIFF
--- a/src/views/About.vue
+++ b/src/views/About.vue
@@ -57,6 +57,14 @@ export default {
         {
           image:
             "https://trafficsignalkit.s3.us-east-2.amazonaws.com/Photos/trafficsignalkit.com-high-resolution-controller-data-explainer-ATSPM.png",
+          title: "Delay Estimator",
+          description: "Estimate detector call delays to phase service",
+          link: "/delay-estimator",
+          topics: ["Controller Data", "Delay", "Enumerations"],
+        },
+        {
+          image:
+            "https://trafficsignalkit.s3.us-east-2.amazonaws.com/Photos/trafficsignalkit.com-high-resolution-controller-data-explainer-ATSPM.png",
           title: "Timeseries Plot All Enumerations",
           description: "Plot preemption (101-119) enumeration events over time",
           link: "/preemption-plotter",

--- a/src/views/DelayEstimator.vue
+++ b/src/views/DelayEstimator.vue
@@ -8,12 +8,11 @@
         <v-expansion-panel title="About: Delay Estimator" value="about">
           <v-expansion-panel-text>
             This tool estimates the delay between the first detector call and
-            when the corresponding phase is served. It uses the first detector
-            ON event within a cycle as the call start and then looks for the
-            phase ON (or phase begin green) event to calculate the delay. If a
-            call is not served before the cycle ends, it will be marked as
-            skipped and the skip timestamp will be recorded at the cycle
-            boundary or the phase skipped event if present.
+            when the corresponding phase is served. You can toggle between
+            using the first detector ON event or the phase call registered
+            event as the call start, and the delay is calculated to the phase
+            ON (or phase begin green) event. Skipped values are only marked
+            when a phase skipped event is present.
           </v-expansion-panel-text>
         </v-expansion-panel>
         <v-expansion-panel title="Example: Using This Tool" value="example">


### PR DESCRIPTION
### Motivation
- Improve the Delay Estimator UI and analysis by allowing alternate call start references and surfacing per-phase summary statistics and cycle metadata.
- Display delays in a compact seconds-only format with one decimal place to match requested presentation.
- Surface the tool on the home page so it is discoverable from the landing grid.

### Description
- Add a timing reference toggle (`timeReference`) to `ProcessDelayEstimator.vue` so users can switch between `Detector On` (event code `82`) and `Phase Call Registered` (event code `43`) as the call start, and recalc on change via a watcher. 
- Add a summary table that computes the average delay per phase (`averageDelayByPhase`) and excludes phases when the value is `-` or when the phase was not served. 
- Add a `Cycle Length` column (seconds) to the cycle-by-cycle table and include `cycleLengthSeconds` in each row. 
- Only mark a phase as skipped when a phase-skipped event (event code `14`) is present; do not synthesize skipped rows from the cycle boundary. 
- Change delay formatting to show seconds with one decimal place (e.g. `67.2 sec`) via `formatDelay`. 
- Add a `Delay Estimator` card to the home page grid (`src/views/About.vue`) and update the estimator description to reflect the toggle and skip-handling behavior. 

### Testing
- Started the dev server with `npm run dev` and confirmed Vite reported the app ready on `http://localhost:4173/` (succeeded). 
- Captured a screenshot of the home page to verify the new Delay Estimator card (Playwright script produced an artifact screenshot successfully). 
- No automated unit tests were run for these UI changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696c58ff5e04832ba4073196cbad0d93)