### PR TITLE
Update detection plot legend and move Process Detection Events button

### DIFF
--- a/src/components/ProcessDetectionEvents.vue
+++ b/src/components/ProcessDetectionEvents.vue
@@ -3,11 +3,6 @@
     <div class="grow-wrap">
       <InputBox v-model="inputData" :defaultText="textboxDefaultText" />
     </div>
-    <div>
-      <v-btn @click="processDetectionEvents" color="primary">
-        Process Detection Events
-      </v-btn>
-    </div>
   </div>
 </template>
 

--- a/src/components/foundational/PlotDetectionTimeSeries.vue
+++ b/src/components/foundational/PlotDetectionTimeSeries.vue
@@ -462,6 +462,35 @@ export default {
         plugins: {
           legend: {
             display: true,
+            labels: {
+              generateLabels: (chart) => {
+                const baseLabels =
+                  ChartJS.defaults.plugins.legend.labels.generateLabels(chart);
+                const filteredLabels = baseLabels.filter(
+                  (label) => label.text !== "Detection Events"
+                );
+                const detectionLegendItems = [
+                  {
+                    text: "Detector On",
+                    fillStyle: "#1e88e5",
+                    strokeStyle: "#1e88e5",
+                    lineWidth: 1,
+                    hidden: false,
+                    pointStyle: "circle",
+                  },
+                  {
+                    text: "Detector Off",
+                    fillStyle: "#8e24aa",
+                    strokeStyle: "#8e24aa",
+                    lineWidth: 1,
+                    hidden: false,
+                    pointStyle: "circle",
+                  },
+                ];
+
+                return [...detectionLegendItems, ...filteredLabels];
+              },
+            },
           },
           tooltip: {
             callbacks: {

--- a/src/views/HighResDetectionPlotter.vue
+++ b/src/views/HighResDetectionPlotter.vue
@@ -43,9 +43,15 @@
 
     <br />
     <ProcessDetectionEvents
+      ref="processDetectionEvents"
       @detectionEvents="storeDetectionEvents"
       @phaseEvents="storePhaseEvents"
     ></ProcessDetectionEvents>
+    <div>
+      <v-btn @click="processDetection" color="primary">
+        Process Detection Events
+      </v-btn>
+    </div>
     <PlotDetectionTimeSeries
       :plotData="detectionEvents"
       :phaseData="phaseEvents"
@@ -71,6 +77,9 @@ export default {
     };
   },
   methods: {
+    processDetection() {
+      this.$refs.processDetectionEvents?.processDetectionEvents?.();
+    },
     storeDetectionEvents(events) {
       this.detectionEvents = events;
     },


### PR DESCRIPTION
### Motivation
- Improve the Timeseries detection chart legend so on/off detector events are explicitly shown instead of a single generic dataset label.
- Move the `Process Detection Events` control out of the input component and into the plotter view so it sits below the input area (better layout and consistent placement with other controls).

### Description
- Removed the inline button from `src/components/ProcessDetectionEvents.vue` so the input component only provides the text input and parsing logic.
- Added a `ref="processDetectionEvents"` and a `Process Detection Events` button to `src/views/HighResDetectionPlotter.vue` which invokes the child method via `this.$refs.processDetectionEvents?.processDetectionEvents?.()`.
- Extended the chart legend in `src/components/foundational/PlotDetectionTimeSeries.vue` by adding a `labels.generateLabels` implementation that filters out the generic "Detection Events" label and prepends explicit legend items for `Detector On` and `Detector Off` with matching styles.

### Testing
- Started the dev server with `npm run dev` and Vite reported the server ready and serving the app (success).
- Verified server reachability with `curl -I http://127.0.0.1:4173` which returned `HTTP/1.1 200 OK` (success).
- Captured an automated screenshot of `http://localhost:4173/detection-plotter` using Playwright which produced `artifacts/detection-plotter.png` after an initial network error that was retried and succeeded (final result: success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696c59d51b80832b9b59bdf51e6123e8)