### PR TITLE
Add pedestrian delay calculations to delay estimator

### DIFF
--- a/src/views/DelayEstimator.vue
+++ b/src/views/DelayEstimator.vue
@@ -8,11 +8,11 @@
         <v-expansion-panel title="About: Delay Estimator" value="about">
           <v-expansion-panel-text>
             This tool estimates the delay between the first detector call and
-            when the corresponding phase is served. You can toggle between
-            using the first detector ON event or the phase call registered
-            event as the call start, and the delay is calculated to the phase
-            ON (or phase begin green) event. Skipped values are only marked
-            when a phase skipped event is present.
+            when the corresponding phase is served. The delay is calculated
+            from detector ON events to the phase ON (or phase begin green)
+            event, and the tool also calculates pedestrian delays from
+            pedestrian button events to phase service. Skipped values are only
+            marked when a phase skipped event is present.
           </v-expansion-panel-text>
         </v-expansion-panel>
         <v-expansion-panel title="Example: Using This Tool" value="example">


### PR DESCRIPTION
### Motivation
- Estimate delays from detector ON events to phase ON for vehicle calls and from pedestrian button (ped detector) events to pedestrian phase service across all phases present in the high-resolution data.
- Surface per-phase averages for both vehicle and pedestrian delays in a summary table and provide cycle-by-cycle tables for vehicle and pedestrian events.
- Simplify the UI by removing the alternate time-reference toggle (phase-call registered option) and always use detector/ped events as the call start.

### Description
- Removed the `timeReference` toggle and related `phaseCall` logic, and calculate delays from detector ON events and pedestrian ON events instead.
- Added `pedTableRows` and `hasPedestrianData` to store and conditionally display pedestrian phase delay rows, and added `averageVehicleDelayByPhase` and `averagePedDelayByPhase` computed properties for summary averages.
- Introduced `findDetectorCallEvent(events, detectorsForPhase, eventCode)` and `populateDelayCell(phaseCells, phase, callEvent, cycleEvents)` helpers to unify vehicle/pedestrian call handling and phase-served/skipped detection.
- Updated templates to show a summary table with `Vehicle Avg Delay` and `Pedestrian Avg Delay`, a vehicle phase table, and a pedestrian phase table (shown only when pedestrian events exist), and updated the `DelayEstimator` description text.

### Testing
- Started the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` and verified Vite reported the local URL as available.
- Loaded the `/delay-estimator` page and captured a screenshot via a Playwright script which successfully rendered the updated UI (screenshot captured during the rollout).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696c7d5d918c832b953dc353290757c9)