### PR TITLE
Add intro callout, About dropdown, and Blog page

### DIFF
--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -73,6 +73,26 @@
         </v-list>
       </v-menu>
     </div>
+    <div class="text-center">
+      <v-menu v-if="mobileViewHide">
+        <template v-slot:activator="{ props }">
+          <v-btn v-bind="props"> About</v-btn>
+        </template>
+
+        <v-list>
+          <v-list-item
+            v-for="(item, index) in AboutTools"
+            :key="index"
+            :to="item.path"
+            link
+            active-class="nav-item-active"
+            class="nav-list-item"
+          >
+            <v-list-item-title>{{ item.title }}</v-list-item-title>
+          </v-list-item>
+        </v-list>
+      </v-menu>
+    </div>
 
     <!--
     <router-link v-for="route in routes" :key="route.path" :to="route.path">
@@ -158,6 +178,8 @@ export default {
         },
         { title: "Reference", path: "/reference" },
         { title: "Practice Exam", path: "/practice-exam" },
+        { title: "About", path: "/about" },
+        { title: "Blog", path: "/blog" },
       ],
 
       TSdataTools: [
@@ -183,6 +205,10 @@ export default {
         },
         { title: "Reference", path: "/reference" },
         { title: "Practice Exam", path: "/practice-exam" },
+      ],
+      AboutTools: [
+        { title: "About Traffic Signal Kit", path: "/about" },
+        { title: "Blog", path: "/blog" },
       ],
 
       dialog: false,

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -18,6 +18,7 @@ import HighResPreemptionPlotter from '../views/HighResPreemptionPlotter'
 import Reference from '../views/Reference'
 import HighResDetectionPlotter from '../views/HighResDetectionPlotter'
 import DelayEstimator from '../views/DelayEstimator'
+import Blog from '../views/Blog'
 
 
 
@@ -31,6 +32,11 @@ const routes = [
         path: '/about',
         name: 'About',
         component: About
+    },
+    {
+        path: '/blog',
+        name: 'Blog',
+        component: Blog
     },
     {  
         path: '/terms-of-service',

--- a/src/views/Blog.vue
+++ b/src/views/Blog.vue
@@ -1,0 +1,35 @@
+<template>
+  <v-container class="blog-page">
+    <h1 class="h1-center-text">Traffic Signal Kit Blog</h1>
+    <v-card class="blog-card" variant="outlined">
+      <v-card-text>
+        <p>
+          Welcome to the Traffic Signal Kit blog. This space will highlight
+          experiment notes, feature deep-dives, and quick updates on new tools
+          as they ship.
+        </p>
+        <p>
+          Have a topic you want covered? Tap the heart button in the header and
+          let me know what you want to see next.
+        </p>
+      </v-card-text>
+    </v-card>
+  </v-container>
+</template>
+
+<script>
+export default {
+  name: "Blog",
+};
+</script>
+
+<style scoped>
+.blog-page {
+  max-width: 960px;
+  margin: 0 auto;
+}
+.blog-card {
+  margin-top: 24px;
+  border-radius: 16px;
+}
+</style>

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -1,16 +1,18 @@
 <template>
   <div>
-    &nbsp;
-    <h1 class="h1-center-text">Traffic Signal Kit</h1>
+    <v-card class="intro-card" variant="outlined">
+      <v-card-text class="intro-text">
+        Various experimental free & open source tools for traffic engineers.
+        These are rapid-fire, proof-of-concept creations designed to innovate,
+        inspire, and provide insights into traffic signal operations. Expect
+        raw, early-stage concepts—this is about speed, experimentation, and
+        finding what truly makes an impact. Your feedback is my roadmap! ❤️
+        Click that heart button to vote on features and shape the future of
+        these tools.
+      </v-card-text>
+    </v-card>
 
-    <h3>
-      Various experimental free & open source tools for traffic engineers. These
-      are rapid-fire, proof-of-concept creations designed to innovate, inspire,
-      and provide insights into traffic signal operations. Expect raw,
-      early-stage concepts—this is about speed, experimentation, and finding
-      what truly makes an impact. Your feedback is my roadmap! ❤️ Click that
-      heart button to vote on features and shape the future of these tools.
-    </h3>
+    <h1 class="h1-center-text">Traffic Signal Kit</h1>
 
     <v-container>
       <v-row no-gutters>
@@ -179,6 +181,17 @@ export default {
 </script>
 
 <style>
+.intro-card {
+  max-width: 960px;
+  margin: 16px auto 24px;
+  border-radius: 16px;
+  background: rgba(0, 150, 136, 0.08);
+}
+.intro-text {
+  font-size: 1.05rem;
+  line-height: 1.6;
+  text-align: left;
+}
 .left-justify-text {
   margin: 0;
   padding: 0;


### PR DESCRIPTION
### Motivation
- Surface the site mission and feedback prompt more prominently by converting the home intro copy into a styled callout. 
- Provide a clear place for project info and updates by adding a dedicated blog page and route at `/blog`.
- Improve navigation on desktop and mobile by adding an `About` dropdown with links to the About page and the Blog.

### Description
- Converted the Home page intro text into a styled callout card by modifying `src/views/Home.vue` and adding `.intro-card`/`.intro-text` styles. 
- Added a new Blog view at `src/views/Blog.vue` with a simple landing card and heading. 
- Registered the new route for the blog in `src/router/index.js` as `/blog`. 
- Updated `src/components/Header.vue` to add an `About` dropdown (desktop) and include `About`/`Blog` links in the mobile drawer.

### Testing
- Attempted to run the dev server with `npm run dev`, but the browser connection/playwright screenshot failed because the local server was not reachable. (failed)
- Attempted a production build with `npm run build`, which started but was interrupted and did not complete. (interrupted)
- No automated tests were added; changes were smoke-tested locally via the build/dev attempts above which did not fully succeed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d010e53a0832bbbab07a795301627)