### PR TITLE
Add Render static.json SPA rewrite

### DIFF
--- a/static.json
+++ b/static.json
@@ -1,0 +1,9 @@
+{
+  "routes": [
+    {
+      "src": "/(.*)",
+      "dest": "/index.html",
+      "status": 200
+    }
+  ]
+}


### PR DESCRIPTION
### Motivation
- Enable SPA deep links so unknown paths (the app uses `createWebHistory` in `src/router/index.js`) return the SPA entry point when served as a static site on hosts like Render.

### Description
- Add `static.json` at the repository root with a catch-all route mapping `/(.*)` to `/index.html` and `status: 200` so all unknown paths are rewritten to the SPA entry.

### Testing
- No automated tests were run because this is a static hosting configuration change only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696dbbba2fc8832ba605aeca63e586d4)