### PR TITLE
Replace KPI headings with divs and add aria-live

### DIFF
--- a/src/components/foundational/DashboardMetric.vue
+++ b/src/components/foundational/DashboardMetric.vue
@@ -11,7 +11,7 @@
             </div>
           </v-card-title>
           <v-card-text justify="center">
-            <h1 class="display-2">{{ yellowRunners }}</h1>
+            <div class="display-2" aria-live="polite">{{ yellowRunners }}</div>
             <p class="average-text">Average Time: {{ yAverageSeconds }}s</p>
           </v-card-text>
         </v-card>
@@ -26,7 +26,7 @@
             </div>
           </v-card-title>
           <v-card-text justify="center">
-            <h1 class="display-2">{{ redClearRunners }}</h1>
+            <div class="display-2" aria-live="polite">{{ redClearRunners }}</div>
             <p class="average-text">Average Time: {{ rcAverageSeconds }}s</p>
           </v-card-text>
         </v-card>
@@ -41,7 +41,7 @@
             </div>
           </v-card-title>
           <v-card-text justify="center">
-            <h1 class="display-2">{{ redRunners }}</h1>
+            <div class="display-2" aria-live="polite">{{ redRunners }}</div>
             <p class="average-text">Average Time: {{ rAverageSeconds }}s</p>
           </v-card-text>
         </v-card>


### PR DESCRIPTION
### Motivation
- Replace visually styled `<h1>` elements used for KPI counters with non-heading elements to avoid inappropriate heading semantics while preserving the existing visual style and improving live region accessibility.

### Description
- Replaced the three `h1` elements for `yellowRunners`, `redClearRunners`, and `redRunners` with `div` elements that keep the `display-2` class and add `aria-live="polite"` to announce updates.
- No other markup or styles were changed and existing `.display-2` styling is preserved.

### Testing
- No automated tests were run (not requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696dc61a62c8832b96001188727a995c)