### PR TITLE
Show processed empty-state when no stuck detectors found

### DIFF
--- a/src/components/ProcessStuckDetectors.vue
+++ b/src/components/ProcessStuckDetectors.vue
@@ -29,7 +29,8 @@
       </v-data-table>
     </div>
     <div v-else class="empty-state">
-      <em>Paste data and click process to find stuck detectors.</em>
+      <em v-if="hasProcessed">No stuck detectors found after processing data.</em>
+      <em v-else>Paste data and click process to find stuck detectors.</em>
     </div>
   </div>
 </template>
@@ -61,6 +62,7 @@ export default {
       ],
       sortBy: [{ key: "percentOn", order: "desc" }],
       tableItems: [],
+      hasProcessed: false,
       dataDefaultText:
         "Paste in High-Resolution Traffic Signal Data as CSV (timestamp, eventCode, channel)",
       detectorDefaultText:
@@ -69,6 +71,7 @@ export default {
   },
   methods: {
     processStuckDetectors() {
+      this.hasProcessed = true;
       const events = this.parseHighResData(this.inputData);
       const { detectorToPhase } = this.parseDetectorMapping(
         this.detectorMapInput


### PR DESCRIPTION
### Motivation
- Make the Stuck Detector Finder UI clearer by showing a distinct message when processing has been run but no stuck detectors were found.

### Description
- Add a `hasProcessed` data property initialized to `false` and set it to `true` at the start of `processStuckDetectors`.
- Update the empty-state template to conditionally render `No stuck detectors found after processing data.` when `hasProcessed` is `true` and preserve the initial guidance otherwise.

### Testing
- Started the dev server with `npm run dev` and ran a Playwright script that navigated to `/#/stuck-detectors` and captured a screenshot, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696dc742db10832bbb702bb13e77b5ed)