### PR TITLE
Remove added image assets and simplify manifest

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,10 +26,8 @@
     content="/src/assets/covershots/trafficsignalkit.com-split-calculator.png"
   />
 
-  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
-<link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png">
-<link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png">
-<link rel="manifest" href="/site.webmanifest">
+  <link rel="icon" href="/favicon.ico">
+  <link rel="manifest" href="/site.webmanifest">
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Traffic Signal Kit</title>
    <!-- Font Awesome -->

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,8 @@
+User-agent: *
+Allow: /
+Disallow: /admin
+Disallow: /api
+Disallow: /draft
+Disallow: /node_modules
+
+Sitemap: https://trafficsignalkit.com/sitemap.xml

--- a/public/site.webmanifest
+++ b/public/site.webmanifest
@@ -1,0 +1,11 @@
+{
+  "name": "Traffic Signal Kit",
+  "short_name": "TrafficSignalKit",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#ffffff",
+  "theme_color": "#009688",
+  "icons": [
+    { "src": "/favicon.ico", "sizes": "any", "type": "image/x-icon" }
+  ]
+}

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://trafficsignalkit.com/</loc></url>
+  <url><loc>https://trafficsignalkit.com/about</loc></url>
+  <url><loc>https://trafficsignalkit.com/blog</loc></url>
+  <url><loc>https://trafficsignalkit.com/terms-of-service</loc></url>
+  <url><loc>https://trafficsignalkit.com/split-calculator</loc></url>
+  <url><loc>https://trafficsignalkit.com/explainer</loc></url>
+  <url><loc>https://trafficsignalkit.com/gpx</loc></url>
+  <url><loc>https://trafficsignalkit.com/split-history</loc></url>
+  <url><loc>https://trafficsignalkit.com/traffic-simulator</loc></url>
+  <url><loc>https://trafficsignalkit.com/phase-plotter</loc></url>
+  <url><loc>https://trafficsignalkit.com/gpx-phase-plotter</loc></url>
+  <url><loc>https://trafficsignalkit.com/gpx-mapper</loc></url>
+  <url><loc>https://trafficsignalkit.com/gpx-elevation</loc></url>
+  <url><loc>https://trafficsignalkit.com/detectorRLR</loc></url>
+  <url><loc>https://trafficsignalkit.com/preemption-plotter</loc></url>
+  <url><loc>https://trafficsignalkit.com/detection-plotter</loc></url>
+  <url><loc>https://trafficsignalkit.com/delay-estimator</loc></url>
+  <url><loc>https://trafficsignalkit.com/practice-exam</loc></url>
+  <url><loc>https://trafficsignalkit.com/message-sign-designer</loc></url>
+  <url><loc>https://trafficsignalkit.com/reference</loc></url>
+</urlset>


### PR DESCRIPTION
### Motivation
- Avoid including binary image files in the PR while keeping crawler and PWA metadata in place. 
- Point Open Graph metadata at an existing source asset and reduce icon references to a single existing favicon for simplicity.

### Description
- Removed newly added binary images from `public/` to keep the public directory text-only and avoid binary attachments. 
- Updated `index.html` to use the local cover asset at `/src/assets/covershots/trafficsignalkit.com-split-calculator.png` for `og:image` and simplified icon links to a single `favicon.ico` and the manifest. 
- Simplified `public/site.webmanifest` to reference `favicon.ico` only in the `icons` array. 
- Added crawler and discovery files `public/robots.txt` and `public/sitemap.xml` to provide basic crawler rules and site routes.

### Testing
- No automated tests were run for these static asset and metadata updates.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696dc58a88c4832b9582f606f54ae68e)