### PR TITLE
Add dynamic SEO head management with @vueuse/head

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,33 +3,14 @@
 
 <head>
   <meta charset="UTF-8" />
-
-  <meta
-    name="description"
-    content="Traffic Signal Kit offers practical Vue.js tools for traffic signal analysis and visualization."
-  />
   <meta
     name="keywords"
     content="traffic signal, traffic engineering, split calculator, traffic data, intersection simulator"
-  />
-  <link rel="canonical" href="https://trafficsignalkit.onrender.com/" />
-
-  <meta property="og:title" content="Traffic Signal Kit" />
-  <meta
-    property="og:description"
-    content="Explore helpful tools for traffic engineers including data visualizers and calculators."
-  />
-  <meta property="og:type" content="website" />
-  <meta property="og:url" content="https://trafficsignalkit.onrender.com/" />
-  <meta
-    property="og:image"
-    content="/src/assets/covershots/trafficsignalkit.com-split-calculator.png"
   />
 
   <link rel="icon" href="/favicon.ico">
   <link rel="manifest" href="/site.webmanifest">
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Traffic Signal Kit</title>
    <!-- Font Awesome -->
    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/css/all.min.css">
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@mapbox/togeojson": "^0.16.2",
         "@mdi/font": "^7.0.96",
+        "@vueuse/head": "^2.0.0",
         "@we-gold/gpxjs": "^1.0.6",
         "@xmldom/xmldom": "^0.8.10",
         "chart.js": "^4.4.3",
@@ -95,7 +96,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "aix"
@@ -111,7 +111,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -127,7 +126,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -143,7 +141,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -159,7 +156,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -175,7 +171,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -191,7 +186,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "freebsd"
@@ -207,7 +201,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "freebsd"
@@ -223,7 +216,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -239,7 +231,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -255,7 +246,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -271,7 +261,6 @@
       "cpu": [
         "loong64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -287,7 +276,6 @@
       "cpu": [
         "mips64el"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -303,7 +291,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -319,7 +306,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -335,7 +321,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -351,7 +336,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -367,7 +351,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "netbsd"
@@ -383,7 +366,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "openbsd"
@@ -399,7 +381,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "sunos"
@@ -415,7 +396,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -431,7 +411,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -447,7 +426,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -1431,7 +1409,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -1444,7 +1421,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -1457,7 +1433,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -1470,7 +1445,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -1483,7 +1457,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -1496,7 +1469,6 @@
       "cpu": [
         "arm"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -1509,7 +1481,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -1522,7 +1493,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -1535,7 +1505,6 @@
       "cpu": [
         "ppc64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -1548,7 +1517,6 @@
       "cpu": [
         "riscv64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -1561,7 +1529,6 @@
       "cpu": [
         "s390x"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -1574,7 +1541,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -1587,7 +1553,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -1600,7 +1565,6 @@
       "cpu": [
         "arm64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -1613,7 +1577,6 @@
       "cpu": [
         "ia32"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -1626,7 +1589,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -1642,7 +1604,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
       "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@types/node": {
       "version": "20.12.11",
@@ -1658,6 +1620,76 @@
       "integrity": "sha512-4YnrRemBShWRO2QjvUin8ESA41rH+9nQGLUGZV/1IDhi3SL9OhdpNC/MrulTWuptXKwhx/aDxE7toV0f/ypIXQ==",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@unhead/dom": {
+      "version": "1.11.20",
+      "resolved": "https://registry.npmjs.org/@unhead/dom/-/dom-1.11.20.tgz",
+      "integrity": "sha512-jgfGYdOH+xHJF/j8gudjsYu3oIjFyXhCWcgKaw3vQnT616gSqyqnGQGOItL+BQtQZACKNISwIfx5PuOtztMKLA==",
+      "license": "MIT",
+      "dependencies": {
+        "@unhead/schema": "1.11.20",
+        "@unhead/shared": "1.11.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/harlan-zw"
+      }
+    },
+    "node_modules/@unhead/schema": {
+      "version": "1.11.20",
+      "resolved": "https://registry.npmjs.org/@unhead/schema/-/schema-1.11.20.tgz",
+      "integrity": "sha512-0zWykKAaJdm+/Y7yi/Yds20PrUK7XabLe9c3IRcjnwYmSWY6z0Cr19VIs3ozCj8P+GhR+/TI2mwtGlueCEYouA==",
+      "license": "MIT",
+      "dependencies": {
+        "hookable": "^5.5.3",
+        "zhead": "^2.2.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/harlan-zw"
+      }
+    },
+    "node_modules/@unhead/shared": {
+      "version": "1.11.20",
+      "resolved": "https://registry.npmjs.org/@unhead/shared/-/shared-1.11.20.tgz",
+      "integrity": "sha512-1MOrBkGgkUXS+sOKz/DBh4U20DNoITlJwpmvSInxEUNhghSNb56S0RnaHRq0iHkhrO/cDgz2zvfdlRpoPLGI3w==",
+      "license": "MIT",
+      "dependencies": {
+        "@unhead/schema": "1.11.20",
+        "packrup": "^0.1.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/harlan-zw"
+      }
+    },
+    "node_modules/@unhead/ssr": {
+      "version": "1.11.20",
+      "resolved": "https://registry.npmjs.org/@unhead/ssr/-/ssr-1.11.20.tgz",
+      "integrity": "sha512-j6ehzmdWGAvv0TEZyLE3WBnG1ULnsbKQcLqBDh3fvKS6b3xutcVZB7mjvrVE7ckSZt6WwOtG0ED3NJDS7IjzBA==",
+      "license": "MIT",
+      "dependencies": {
+        "@unhead/schema": "1.11.20",
+        "@unhead/shared": "1.11.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/harlan-zw"
+      }
+    },
+    "node_modules/@unhead/vue": {
+      "version": "1.11.20",
+      "resolved": "https://registry.npmjs.org/@unhead/vue/-/vue-1.11.20.tgz",
+      "integrity": "sha512-sqQaLbwqY9TvLEGeq8Fd7+F2TIuV3nZ5ihVISHjWpAM3y7DwNWRU7NmT9+yYT+2/jw1Vjwdkv5/HvDnvCLrgmg==",
+      "license": "MIT",
+      "dependencies": {
+        "@unhead/schema": "1.11.20",
+        "@unhead/shared": "1.11.20",
+        "hookable": "^5.5.3",
+        "unhead": "1.11.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/harlan-zw"
+      },
+      "peerDependencies": {
+        "vue": ">=2.7 || >=3"
       }
     },
     "node_modules/@vitejs/plugin-vue": {
@@ -1678,6 +1710,7 @@
       "resolved": "https://registry.npmjs.org/@vue-leaflet/vue-leaflet/-/vue-leaflet-0.10.1.tgz",
       "integrity": "sha512-RNEDk8TbnwrJl8ujdbKgZRFygLCxd0aBcWLQ05q/pGv4+d0jamE3KXQgQBqGAteE1mbQsk3xoNcqqUgaIGfWVg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "vue": "^3.2.25"
       },
@@ -1790,13 +1823,28 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@vuetify/loader-shared/-/loader-shared-2.0.3.tgz",
       "integrity": "sha512-Ss3GC7eJYkp2SF6xVzsT7FAruEmdihmn4OCk2+UocREerlXKWgOKKzTN5PN3ZVN5q05jHHrsNhTuWbhN61Bpdg==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "upath": "^2.0.1"
       },
       "peerDependencies": {
         "vue": "^3.0.0",
         "vuetify": "^3.0.0"
+      }
+    },
+    "node_modules/@vueuse/head": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/head/-/head-2.0.0.tgz",
+      "integrity": "sha512-ykdOxTGs95xjD4WXE4na/umxZea2Itl0GWBILas+O4oqS7eXIods38INvk3XkJKjqMdWPcpCyLX/DioLQxU1KA==",
+      "license": "MIT",
+      "dependencies": {
+        "@unhead/dom": "^1.7.0",
+        "@unhead/schema": "^1.7.0",
+        "@unhead/ssr": "^1.7.0",
+        "@unhead/vue": "^1.7.0"
+      },
+      "peerDependencies": {
+        "vue": ">=2.7 || >=3"
       }
     },
     "node_modules/@we-gold/gpxjs": {
@@ -1891,7 +1939,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
       "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "normalize-path": "^3.0.0",
         "picomatch": "^2.0.4"
@@ -2053,7 +2101,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
       "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=8"
       },
@@ -2091,7 +2139,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
       "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "fill-range": "^7.0.1"
       },
@@ -2195,7 +2243,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
       "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
@@ -2424,7 +2472,7 @@
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
       "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -2548,7 +2596,7 @@
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.20.2.tgz",
       "integrity": "sha512-WdOOppmUNU+IbZ0PaDiTst80zjnrOkyJNHoKupIcVyU8Lvla3Ugx94VzkQ32Ijqd7UhHJy75gNWDMUekcrSJ6g==",
-      "dev": true,
+      "devOptional": true,
       "hasInstallScript": true,
       "bin": {
         "esbuild": "bin/esbuild"
@@ -2759,7 +2807,7 @@
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
       "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -2804,7 +2852,6 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-      "dev": true,
       "hasInstallScript": true,
       "optional": true,
       "os": [
@@ -2880,7 +2927,7 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "is-glob": "^4.0.1"
       },
@@ -2961,6 +3008,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/hookable": {
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/hookable/-/hookable-5.5.3.tgz",
+      "integrity": "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==",
+      "license": "MIT"
     },
     "node_modules/html-encoding-sniffer": {
       "version": "1.0.2",
@@ -3049,7 +3102,7 @@
       "version": "4.3.5",
       "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.5.tgz",
       "integrity": "sha512-8eabxkth9gZatlwl5TBuJnCsoTADlL6ftEr7A4qgdaTsPyreilDSnUk57SO+jfKcNtxPa22U5KK6DSeAYhpBJw==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/inherits": {
       "version": "2.0.4",
@@ -3087,7 +3140,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
       "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "binary-extensions": "^2.0.0"
       },
@@ -3111,7 +3164,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -3138,7 +3191,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "is-extglob": "^2.1.1"
       },
@@ -3150,7 +3203,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=0.12.0"
       }
@@ -3298,7 +3351,8 @@
       "version": "1.9.4",
       "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
       "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
-      "dev": true
+      "dev": true,
+      "license": "BSD-2-Clause"
     },
     "node_modules/leaflet-easyprint": {
       "version": "2.1.9",
@@ -3505,7 +3559,7 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/nanoid": {
       "version": "3.3.7",
@@ -3558,7 +3612,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5987,6 +6041,15 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/packrup": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/packrup/-/packrup-0.1.2.tgz",
+      "integrity": "sha512-ZcKU7zrr5GlonoS9cxxrb5HVswGnyj6jQvwFBa6p5VFw7G71VAHcUKL5wyZSU/ECtPM/9gacWxy2KFQKt1gMNA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/harlan-zw"
+      }
+    },
     "node_modules/pako": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
@@ -6103,7 +6166,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=8.6"
       },
@@ -6402,7 +6465,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
       "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "picomatch": "^2.2.1"
       },
@@ -6655,7 +6718,7 @@
       "version": "4.17.2",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.17.2.tgz",
       "integrity": "sha512-/9ClTJPByC0U4zNLowV1tMBe8yMEAxewtR3cUNX5BoEpGH3dQEWpJLr6CLp0fPdYRF/fzVOgvDb1zXuakwF5kQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@types/estree": "1.0.5"
       },
@@ -6737,7 +6800,7 @@
       "version": "1.77.1",
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.77.1.tgz",
       "integrity": "sha512-OMEyfirt9XEfyvocduUIOlUSkWOXS/LAt6oblR/ISXCTukyavjex+zQNm51pPCOiFKY1QpWvEH1EeCkgyV3I6w==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "chokidar": ">=3.0.0 <4.0.0",
         "immutable": "^4.0.0",
@@ -7079,7 +7142,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "is-number": "^7.0.0"
       },
@@ -7168,6 +7231,21 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
     },
+    "node_modules/unhead": {
+      "version": "1.11.20",
+      "resolved": "https://registry.npmjs.org/unhead/-/unhead-1.11.20.tgz",
+      "integrity": "sha512-3AsNQC0pjwlLqEYHLjtichGWankK8yqmocReITecmpB1H0aOabeESueyy+8X1gyJx4ftZVwo9hqQ4O3fPWffCA==",
+      "license": "MIT",
+      "dependencies": {
+        "@unhead/dom": "1.11.20",
+        "@unhead/schema": "1.11.20",
+        "@unhead/shared": "1.11.20",
+        "hookable": "^5.5.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/harlan-zw"
+      }
+    },
     "node_modules/unplugin": {
       "version": "1.10.1",
       "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-1.10.1.tgz",
@@ -7255,7 +7333,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/upath/-/upath-2.0.1.tgz",
       "integrity": "sha512-1uEe95xksV1O0CYKXo8vQvN1JEbtJp7lb7C5U9HMsIp6IVwntkH/oNUzyVNQSd4S1sYk2FpSSW44FqMc8qee5w==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=4",
         "yarn": "*"
@@ -7347,7 +7425,7 @@
       "version": "5.2.11",
       "resolved": "https://registry.npmjs.org/vite/-/vite-5.2.11.tgz",
       "integrity": "sha512-HndV31LWW05i1BLPMUCE1B9E9GFbOu1MbenhS58FuK6owSO5qHm7GiCotrNY1YE5rMeQSFBGmT5ZaLEjFizgiQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "esbuild": "^0.20.1",
         "postcss": "^8.4.38",
@@ -7531,7 +7609,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/vite-plugin-vuetify/-/vite-plugin-vuetify-2.0.3.tgz",
       "integrity": "sha512-HbYajgGgb/noaVKNRhnnXIiQZrNXfNIeanUGAwXgOxL6h/KULS40Uf51Kyz8hNmdegF+DwjgXXI/8J1PNS83xw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@vuetify/loader-shared": "^2.0.3",
         "debug": "^4.3.3",
@@ -7782,6 +7860,15 @@
       "dev": true,
       "engines": {
         "node": ">=0.4"
+      }
+    },
+    "node_modules/zhead": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/zhead/-/zhead-2.2.4.tgz",
+      "integrity": "sha512-8F0OI5dpWIA5IGG5NHUg9staDwz/ZPxZtvGVf01j7vHqSyZ0raHY+78atOVxRqb73AotX22uV1pXt3gYSstGag==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/harlan-zw"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "@mapbox/togeojson": "^0.16.2",
     "@mdi/font": "^7.0.96",
+    "@vueuse/head": "^2.0.0",
     "@we-gold/gpxjs": "^1.0.6",
     "@xmldom/xmldom": "^0.8.10",
     "chart.js": "^4.4.3",

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,6 +1,7 @@
 <template>
   <v-app>
     <div>
+      <HeadManager />
       <Header></Header>
       <v-row>
         <v-col md="1" xs="0"></v-col>
@@ -19,12 +20,14 @@
 <script>
 import Header from "./components/Header.vue";
 import Footer from "./components/Footer.vue";
+import HeadManager from "./seo/HeadManager.vue";
 
 export default {
   name: "App",
   components: {
     Header,
     Footer,
+    HeadManager,
   },
   data: () => ({
     tab: null,

--- a/src/main.js
+++ b/src/main.js
@@ -7,6 +7,7 @@
 // Plugins
 import { registerPlugins } from '@/plugins'
 import { createPinia } from 'pinia';
+import { createHead } from '@vueuse/head';
 
 // Components
 import App from './App.vue'
@@ -44,11 +45,13 @@ export default createVuetify({
 
 
 const app = createApp(App)
+const head = createHead();
 
 registerPlugins(app)
 
 app.use(router)
 app.use(createPinia());
+app.use(head);
 
 
 app.mount('#app')

--- a/src/seo/HeadManager.vue
+++ b/src/seo/HeadManager.vue
@@ -1,0 +1,37 @@
+<template></template>
+
+<script setup>
+import { computed } from "vue";
+import { useRoute } from "vue-router";
+import { useHead } from "@vueuse/head";
+import { site, absoluteUrl } from "./site";
+import { routeMeta } from "./routes";
+
+const route = useRoute();
+const meta = computed(() => routeMeta[route.name] || {});
+const title = computed(() => meta.value.title || site.defaultTitle);
+const description = computed(
+  () => meta.value.description || site.defaultDescription
+);
+const canonical = computed(() => absoluteUrl(meta.value.path || route.path));
+const ogImage = computed(() =>
+  absoluteUrl(meta.value.ogImage || site.defaultOgImage)
+);
+
+useHead(() => ({
+  title: title.value,
+  meta: [
+    { name: "description", content: description.value },
+    { property: "og:title", content: title.value },
+    { property: "og:description", content: description.value },
+    { property: "og:url", content: canonical.value },
+    { property: "og:type", content: "website" },
+    { property: "og:image", content: ogImage.value },
+    { name: "twitter:card", content: "summary_large_image" },
+    { name: "twitter:title", content: title.value },
+    { name: "twitter:description", content: description.value },
+    { name: "twitter:image", content: ogImage.value },
+  ],
+  link: [{ rel: "canonical", href: canonical.value }],
+}));
+</script>

--- a/src/seo/routes.js
+++ b/src/seo/routes.js
@@ -1,0 +1,133 @@
+export const routeMeta = {
+  home: {
+    title: "Traffic Signal Kit | ATSPM & High-Resolution Signal Tools",
+    description:
+      "Analyze traffic signal performance with ATSPM metrics, high-resolution data visualizers, GPX time-space tools, and split calculators.",
+    path: "/",
+  },
+  About: {
+    title: "About Traffic Signal Kit | Traffic Signal Engineering Tools",
+    description:
+      "Learn how Traffic Signal Kit supports traffic engineers with controller event analysis, split history, and GPX visualization tools.",
+    path: "/about",
+  },
+  Blog: {
+    title: "Traffic Signal Kit Blog | ATSPM & Traffic Signal Insights",
+    description:
+      "Updates, experiments, and explainers on ATSPM metrics, high-resolution controller data, and signal timing workflows.",
+    path: "/blog",
+  },
+  TermsOfService: {
+    title: "Terms of Service | Traffic Signal Kit",
+    description:
+      "Terms and conditions for using the Traffic Signal Kit tools and services.",
+    path: "/terms-of-service",
+  },
+  SplitCalculator: {
+    title: "Traffic Signal Split Calculator | Coordination & Timing Checks",
+    description:
+      "Verify split allocations and cycle lengths during coordination and timing plan adjustments.",
+    path: "/split-calculator",
+  },
+  HighResDataExplainer: {
+    title: "High-Resolution Controller Data Explainer | ATSPM Events",
+    description:
+      "Understand ATSPM event enumerations and how high-resolution controller logs map to signal behavior.",
+    path: "/explainer",
+  },
+  gpxPlotter: {
+    title: "GPX Time-Space Diagram Visualizer | Traffic Signal Analysis",
+    description:
+      "Plot GPX traces in time-space diagrams to evaluate progression and travel time.",
+    path: "/gpx",
+  },
+  splitHistory: {
+    title: "High-Resolution Split History | Phase Termination Analysis",
+    description:
+      "Calculate phase durations from high-resolution controller events to evaluate split performance.",
+    path: "/split-history",
+  },
+  trafficSim: {
+    title: "Traffic Signal Timing Simulator | Gap Out & Max Out",
+    description:
+      "Simulate basic intersection operations to understand gap-out/max-out behavior.",
+    path: "/traffic-simulator",
+  },
+  phasePlotter: {
+    title: "Signal Phase Plotter | Red-Green-Yellow Visualization",
+    description:
+      "Plot phase states over time to troubleshoot timing logic and controller behavior.",
+    path: "/phase-plotter",
+  },
+  gpxPhasePlotter: {
+    title: "GPX + Phase Plotter | Time-Space & TSP Events",
+    description:
+      "Compare GPX movement with phase states and transit signal priority events.",
+    path: "/gpx-phase-plotter",
+  },
+  gpxMapper: {
+    title: "GPX Mapper | Map-Based Trace Visualization",
+    description:
+      "Map GPX tracks spatially to validate alignment and routes.",
+    path: "/gpx-mapper",
+  },
+  gpxElevation: {
+    title: "GPX Elevation Plotter | Grade & Profile Insights",
+    description:
+      "Plot elevation data from GPX files to analyze grade and profiles.",
+    path: "/gpx-elevation",
+  },
+  detectorRLR: {
+    title: "Red Light Running Detection | High-Resolution Events",
+    description:
+      "Analyze yellow/red light running events from controller and detection data.",
+    path: "/detectorRLR",
+  },
+  preemptionPlotter: {
+    title: "Preemption Timeseries Plotter | Enumeration Diagnostics",
+    description:
+      "Plot preemption enumerations (101-119) over time for diagnostics.",
+    path: "/preemption-plotter",
+  },
+  detectionPlotter: {
+    title: "Detection Channel Plotter | Detector Health & Events",
+    description:
+      "Visualize detection events by channel to validate detector performance.",
+    path: "/detection-plotter",
+  },
+  delayEstimator: {
+    title: "Detector Call Delay Estimator | Phase Service Timing",
+    description:
+      "Estimate call delays between detector actuations and phase service.",
+    path: "/delay-estimator",
+  },
+  stuckDetectors: {
+    title: "Stuck Detector Diagnostics | Signal Health Checks",
+    description:
+      "Identify detector channels that appear stuck on or off in high-resolution data.",
+    path: "/stuck-detectors",
+  },
+  practiceExam: {
+    title: "Traffic Signal Practice Exam | Certification Prep",
+    description:
+      "Practice multiple-choice questions for traffic engineering and signal timing.",
+    path: "/practice-exam",
+  },
+  messageSignDesigner: {
+    title: "Changeable Message Sign Designer | CMS Preview",
+    description:
+      "Preview changeable message sign text with realistic sizing.",
+    path: "/message-sign-designer",
+  },
+  Reference: {
+    title: "Traffic Signal Reference | Quick Notes & Resources",
+    description:
+      "Quick reference notes and resources for traffic signal timing work.",
+    path: "/reference",
+  },
+  "not-found": {
+    title: "Page Not Found | Traffic Signal Kit",
+    description: "The requested page could not be found.",
+    path: "/",
+  },
+};

--- a/src/seo/site.js
+++ b/src/seo/site.js
@@ -1,0 +1,12 @@
+export const site = {
+  name: "Traffic Signal Kit",
+  baseUrl: "https://trafficsignalkit.com",
+  defaultTitle: "Traffic Signal Kit | ATSPM & High-Resolution Signal Tools",
+  defaultDescription:
+    "Open-source tools for traffic signal timing, ATSPM metrics, high-resolution controller data, and GPX time-space visualization.",
+  defaultOgImage: "/og/traffic-signal-kit.png",
+  twitterHandle: "@trafficsignalkit",
+};
+
+export const absoluteUrl = (path = "/") =>
+  new URL(path, site.baseUrl).toString();


### PR DESCRIPTION
### Motivation
- Replace hard-coded HTML meta tags with a dynamic, route-aware head manager so page titles, descriptions, canonical URLs, and social cards are generated per route.
- Centralize site and route metadata to make SEO text consistent and easier to update across the app.

### Description
- Add dependency `@vueuse/head` and wire it into the app by calling `createHead()` and registering it with `app.use(head)` in `src/main.js`.
- Add `src/seo/site.js` and `src/seo/routes.js` to hold global site metadata and per-route metadata respectively, including new entries for `stuckDetectors` and `not-found`.
- Add `src/seo/HeadManager.vue` which reads `useRoute()` and `routeMeta` and uses `useHead()` to set `title`, `meta` (description/OG/twitter), and canonical `link` dynamically.
- Mount `<HeadManager />` in `App.vue` so head updates run on every route and remove conflicting static meta (title/description/OG/canonical) from `index.html`; update `package.json`/lockfile to include the new dependency.

### Testing
- Run `npm install @vueuse/head` which completed and added the new packages (install output noted audit warnings but succeeded). 
- No automated unit or integration tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696dcdd27b8c832baedd347bf12c5f99)