### PR TITLE
Add JSON-LD metadata and FAQ content

### DIFF
--- a/src/seo/HeadManager.vue
+++ b/src/seo/HeadManager.vue
@@ -6,6 +6,11 @@ import { useRoute } from "vue-router";
 import { useHead } from "@vueuse/head";
 import { site, absoluteUrl } from "./site";
 import { routeMeta } from "./routes";
+import {
+  organizationJsonLd,
+  websiteJsonLd,
+  softwareApplicationJsonLd,
+} from "./jsonld";
 
 const route = useRoute();
 const meta = computed(() => routeMeta[route.name] || {});
@@ -16,6 +21,19 @@ const description = computed(
 const canonical = computed(() => absoluteUrl(meta.value.path || route.path));
 const ogImage = computed(() =>
   absoluteUrl(meta.value.ogImage || site.defaultOgImage)
+);
+const faqJsonLd = computed(() =>
+  meta.value.faq
+    ? {
+        "@context": "https://schema.org",
+        "@type": "FAQPage",
+        mainEntity: meta.value.faq.map(({ question, answer }) => ({
+          "@type": "Question",
+          name: question,
+          acceptedAnswer: { "@type": "Answer", text: answer },
+        })),
+      }
+    : null
 );
 
 useHead(() => ({
@@ -33,5 +51,24 @@ useHead(() => ({
     { name: "twitter:image", content: ogImage.value },
   ],
   link: [{ rel: "canonical", href: canonical.value }],
+  script: [
+    {
+      type: "application/ld+json",
+      children: JSON.stringify(organizationJsonLd),
+    },
+    { type: "application/ld+json", children: JSON.stringify(websiteJsonLd) },
+    {
+      type: "application/ld+json",
+      children: JSON.stringify(softwareApplicationJsonLd),
+    },
+    ...(faqJsonLd.value
+      ? [
+          {
+            type: "application/ld+json",
+            children: JSON.stringify(faqJsonLd.value),
+          },
+        ]
+      : []),
+  ],
 }));
 </script>

--- a/src/seo/jsonld.js
+++ b/src/seo/jsonld.js
@@ -1,0 +1,26 @@
+import { site, absoluteUrl } from "./site";
+
+export const organizationJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "Organization",
+  name: site.name,
+  url: site.baseUrl,
+  logo: absoluteUrl("/og/traffic-signal-kit.png"),
+};
+
+export const websiteJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "WebSite",
+  name: site.name,
+  url: site.baseUrl,
+};
+
+export const softwareApplicationJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "SoftwareApplication",
+  name: "Traffic Signal Kit",
+  applicationCategory: "DeveloperApplication",
+  operatingSystem: "Web",
+  url: site.baseUrl,
+  description: site.defaultDescription,
+};

--- a/src/seo/routes.js
+++ b/src/seo/routes.js
@@ -34,6 +34,18 @@ export const routeMeta = {
     description:
       "Understand ATSPM event enumerations and how high-resolution controller logs map to signal behavior.",
     path: "/explainer",
+    faq: [
+      {
+        question: "What does high-resolution controller data capture?",
+        answer:
+          "It records controller events, signal states, and timing changes at 100 millisecond resolution for analysis.",
+      },
+      {
+        question: "What format should I paste into the explainer?",
+        answer:
+          "Paste CSV rows that include a timestamp, event enumeration, and parameter such as phase or channel number.",
+      },
+    ],
   },
   gpxPlotter: {
     title: "GPX Time-Space Diagram Visualizer | Traffic Signal Analysis",
@@ -46,6 +58,18 @@ export const routeMeta = {
     description:
       "Calculate phase durations from high-resolution controller events to evaluate split performance.",
     path: "/split-history",
+    faq: [
+      {
+        question: "What does the split history report show?",
+        answer:
+          "It summarizes each phase run time and indicates whether phases gapped out, maxed out, or were forced off.",
+      },
+      {
+        question: "How is split history calculated?",
+        answer:
+          "The tool derives phase durations from high-resolution event logs between the start of green and end of red.",
+      },
+    ],
   },
   trafficSim: {
     title: "Traffic Signal Timing Simulator | Gap Out & Max Out",
@@ -58,6 +82,18 @@ export const routeMeta = {
     description:
       "Plot phase states over time to troubleshoot timing logic and controller behavior.",
     path: "/phase-plotter",
+    faq: [
+      {
+        question: "What does the phase plotter visualize?",
+        answer:
+          "It charts the state of each phase over time using high-resolution controller event data.",
+      },
+      {
+        question: "How can I use the phase plotter results?",
+        answer:
+          "Use the plot to troubleshoot timing logic, verify phase sequences, and spot unexpected transitions.",
+      },
+    ],
   },
   gpxPhasePlotter: {
     title: "GPX + Phase Plotter | Time-Space & TSP Events",

--- a/src/views/HighResDataExplainer.vue
+++ b/src/views/HighResDataExplainer.vue
@@ -94,6 +94,24 @@
     </div>
     <br />
 
+    <section class="left-justify-text faq-section">
+      <h2>FAQ</h2>
+      <div class="faq-item">
+        <h3>What does high-resolution controller data capture?</h3>
+        <p>
+          It records controller events, signal states, and timing changes at 100
+          millisecond resolution for analysis.
+        </p>
+      </div>
+      <div class="faq-item">
+        <h3>What format should I paste into the explainer?</h3>
+        <p>
+          Paste CSV rows that include a timestamp, event enumeration, and a
+          parameter such as a phase or channel number.
+        </p>
+      </div>
+    </section>
+
     <CSVInput @csvDataProcessed="handleProcessedData" />
 
     <ProcessedData v-if="processedData" :data="processedData" />

--- a/src/views/HighResPhasePlotter.vue
+++ b/src/views/HighResPhasePlotter.vue
@@ -98,6 +98,25 @@
       </v-expansion-panels>
     </div>
     <br />
+
+    <section class="left-justify-text faq-section">
+      <h2>FAQ</h2>
+      <div class="faq-item">
+        <h3>What does the phase plotter visualize?</h3>
+        <p>
+          It charts the state of each phase over time using high-resolution
+          controller event data.
+        </p>
+      </div>
+      <div class="faq-item">
+        <h3>How can I use the phase plotter results?</h3>
+        <p>
+          Use the plot to troubleshoot timing logic, verify phase sequences,
+          and spot unexpected transitions.
+        </p>
+      </div>
+    </section>
+
     <ProcessSplitHistory
       @phaseDurations="storePhaseDuration"
     ></ProcessSplitHistory>

--- a/src/views/SplitHistory.vue
+++ b/src/views/SplitHistory.vue
@@ -97,6 +97,25 @@
       </v-expansion-panels>
     </div>
     <br />
+
+    <section class="left-justify-text faq-section">
+      <h2>FAQ</h2>
+      <div class="faq-item">
+        <h3>What does the split history report show?</h3>
+        <p>
+          It summarizes each phase run time and indicates whether phases gapped
+          out, maxed out, or were forced off.
+        </p>
+      </div>
+      <div class="faq-item">
+        <h3>How is split history calculated?</h3>
+        <p>
+          The tool derives phase durations from high-resolution event logs
+          between the start of green and end of red.
+        </p>
+      </div>
+    </section>
+
     <ProcessSplitHistory
       @phaseDurations="displayPhaseDuration"
     ></ProcessSplitHistory>


### PR DESCRIPTION
### Motivation
- Provide structured schema.org JSON-LD for the site (organization, website, software application) and surface page FAQs as JSON-LD to improve SEO and enable rich results.

### Description
- Add `src/seo/jsonld.js` exporting `organizationJsonLd`, `websiteJsonLd`, and `softwareApplicationJsonLd` objects.
- Update `src/seo/HeadManager.vue` to inject the JSON-LD script tags via `useHead` and compute an optional `FAQPage` JSON-LD from route meta.
- Extend `src/seo/routes.js` with `faq` arrays for `HighResDataExplainer`, `splitHistory`, and `phasePlotter` routes.
- Add visible FAQ sections to `src/views/HighResDataExplainer.vue`, `src/views/SplitHistory.vue`, and `src/views/HighResPhasePlotter.vue` to match the route metadata.

### Testing
- Ran `npm run dev` to start the Vite dev server, but Vite reported an unresolved dependency `@vueuse/head`, preventing full validation of head injection (failed).
- Attempted to fetch pages and capture a screenshot with Playwright, but the page load/screenshot attempt failed because the dev server was not reachable (failed).
- `git commit` completed successfully with the changes staged and recorded (operation succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696dd0df2a58832bb1919aca0f6299a6)