### PR TITLE
Add skip link and main content wrapper

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,18 +1,13 @@
 <template>
   <v-app>
+    <a class="skip-link" href="#main-content">Skip to content</a>
     <div>
       <HeadManager />
-      <Header></Header>
-      <v-row>
-        <v-col md="1" xs="0"></v-col>
-      </v-row>
-      <v-col>
-        <router-view></router-view>
-      </v-col>
-      <v-row>
-        <v-col md="1" xs="0"></v-col>
-      </v-row>
-      <Footer> </Footer>
+      <Header />
+      <main id="main-content">
+        <router-view />
+      </main>
+      <Footer />
     </div>
   </v-app>
 </template>
@@ -34,4 +29,17 @@ export default {
   }),
 };
 </script>
-<style></style>
+<style>
+.skip-link {
+  position: absolute;
+  left: -999px;
+  top: 8px;
+  background: #009688;
+  color: white;
+  padding: 8px 12px;
+  z-index: 9999;
+}
+.skip-link:focus {
+  left: 8px;
+}
+</style>


### PR DESCRIPTION
### Motivation

- Improve keyboard accessibility by adding a visible skip link and a proper main landmark for routed content.

### Description

- Updated `src/App.vue` to insert a skip link (`<a class="skip-link" href="#main-content">Skip to content</a>`), wrap the routed view in `<main id="main-content">`, and simplify header/footer markup.
- Added minimal CSS for `.skip-link` and `.skip-link:focus` directly in `src/App.vue` to keep the link visually offscreen until focused.

### Testing

- Ran `npm run dev -- --host 0.0.0.0 --port 4173` but the Vite dev server failed to start due to a missing `@vueuse/head` dependency, so the app could not be served.
- Attempted an automated browser screenshot with Playwright, but it could not connect because the dev server was not running.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696dd3898d20832b8658e12469b39589)