### PR TITLE
Remove detector mapping input from stuck detector finder

### DIFF
--- a/src/components/ProcessStuckDetectors.vue
+++ b/src/components/ProcessStuckDetectors.vue
@@ -4,12 +4,6 @@
       <div class="grow-wrap">
         <InputBox v-model="inputData" :defaultText="dataDefaultText" />
       </div>
-      <div class="grow-wrap">
-        <InputBox
-          v-model="detectorMapInput"
-          :defaultText="detectorDefaultText"
-        />
-      </div>
     </div>
     <div class="actions">
       <v-btn @click="processStuckDetectors" color="primary">Process</v-btn>
@@ -50,10 +44,8 @@ export default {
   data() {
     return {
       inputData: "",
-      detectorMapInput: "",
       headers: [
         { title: "Detector ID", key: "detectorId", sortable: true },
-        { title: "Phase #", key: "phase", sortable: true },
         {
           title: "Percent Time On",
           key: "percentOn",
@@ -65,17 +57,12 @@ export default {
       hasProcessed: false,
       dataDefaultText:
         "Paste in High-Resolution Traffic Signal Data as CSV (timestamp, eventCode, channel)",
-      detectorDefaultText:
-        "Det 1\t6\nDet 2\t2\nDet 3\t0\nDet 4\t0\nDet 5\t0",
     };
   },
   methods: {
     processStuckDetectors() {
       this.hasProcessed = true;
       const events = this.parseHighResData(this.inputData);
-      const { detectorToPhase } = this.parseDetectorMapping(
-        this.detectorMapInput
-      );
 
       if (events.length < 2) {
         this.tableItems = [];
@@ -146,35 +133,11 @@ export default {
         const percentOn = (stats.onDuration / totalDuration) * 100;
         items.push({
           detectorId: stats.detectorId,
-          phase: detectorToPhase[stats.detectorId] ?? "-",
           percentOn,
         });
       });
 
       this.tableItems = items.sort((a, b) => b.percentOn - a.percentOn);
-    },
-    parseDetectorMapping(text) {
-      const detectorToPhase = {};
-
-      text
-        .split("\n")
-        .map((line) => line.trim())
-        .filter((line) => line)
-        .forEach((line) => {
-          const matches = line.match(/\d+/g);
-          if (!matches || matches.length < 2) {
-            return;
-          }
-          const detector = Number(matches[0]);
-          const phase = Number(matches[1]);
-          if (!Number.isNaN(detector) && phase > 0) {
-            detectorToPhase[detector] = phase;
-          }
-        });
-
-      return {
-        detectorToPhase,
-      };
     },
     parseHighResData(text) {
       return text

--- a/src/views/StuckDetectors.vue
+++ b/src/views/StuckDetectors.vue
@@ -16,8 +16,7 @@
 
         <v-expansion-panel title="Example: Using This Tool" value="example">
           <v-expansion-panel-text>
-            Paste high-resolution data in the first box and detector-to-phase
-            assignments in the second box. Click Process to see detectors that
+            Paste high-resolution data and click Process to see detectors that
             never appear to turn off during the data window.
           </v-expansion-panel-text>
         </v-expansion-panel>


### PR DESCRIPTION
### Motivation

- Simplify the Stuck Detector Finder UI and logic so it only requires high-resolution detector data and no longer depends on a separate detector-to-phase mapping input.

### Description

- Remove the detector-to-phase `InputBox` and its backing `detectorMapInput`/`detectorDefaultText` from `src/components/ProcessStuckDetectors.vue`.
- Drop the `Phase #` column from the results table and stop attempting to populate a `phase` value in the output items.
- Remove the `parseDetectorMapping` helper and the call that extracted `detectorToPhase` so processing is based solely on parsed high-resolution events.
- Update the example guidance copy in `src/views/StuckDetectors.vue` to reflect the single-input workflow.

### Testing

- Attempted to start the dev server with `npm run dev`, but Vite failed to fully serve due to an unresolved dependency `@vueuse/head`, so the local dev server check did not complete.
- A Playwright screenshot/navigation script was run but failed because the dev server was not reachable, so UI end-to-end verification did not complete.
- No automated unit tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696dd327040c832b9208d6e13b6b495b)