### PR TITLE
Add row count display to High Resolution Data Explainer table

### DIFF
--- a/src/components/CSVInput.vue
+++ b/src/components/CSVInput.vue
@@ -22,7 +22,10 @@
 
         <v-card-text>
           <div>
-            <div class="table-actions">
+            <div class="table-toolbar">
+              <div class="table-count">
+                Rows in table: {{ filteredRows.length }}
+              </div>
               <v-btn
                 color="secondary"
                 :disabled="!rowData.length"
@@ -542,10 +545,16 @@ select {
   box-sizing: border-box;
   margin-top: 25px;
 }
-.table-actions {
+.table-toolbar {
   display: flex;
-  justify-content: flex-end;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
   margin-bottom: 12px;
+}
+.table-count {
+  font-weight: 600;
+  color: #4a4a4a;
 }
 dd {
   margin-left: 0;


### PR DESCRIPTION
### Motivation
- Provide users with immediate feedback about how many rows are visible in the High Resolution Data Explainer table so they can see the effect of filters and know what will be exported.

### Description
- Added a compact toolbar above the table filters in `src/components/CSVInput.vue` that shows `Rows in table: {{ filteredRows.length }}` next to the `Export to Excel` button.
- Replaced the previous `.table-actions` wrapper with a `.table-toolbar` element and added a `.table-count` style to emphasize the count label.
- Updated CSS to align and space the toolbar elements (`.table-toolbar` and `.table-count`).

### Testing
- Ran the development server with `npm run dev -- --host 0.0.0.0 --port 4173` which failed to start because Vite reported unresolved imports in `src/router/index.js`, so the UI could not be loaded for interactive verification (failure reproduced and logged).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696dd7959b14832b8c7621b39f2ecc56)