### PR TITLE
Enhance Signal Offset Calculator: pattern summaries, phase-history, swap control, beginning-of-red

### DIFF
--- a/src/views/SignalOffsetCalculator.vue
+++ b/src/views/SignalOffsetCalculator.vue
@@ -11,7 +11,7 @@
             the offset between coordinated phases for every cycle in the
             high-resolution data. Paste in both data sets, pick the coordinated
             phase for each signal, and choose the event you want to align
-            (start of green, start of yellow, or end of yellow).
+            (start of green, start of yellow, or beginning of red).
           </v-expansion-panel-text>
         </v-expansion-panel>
 
@@ -31,7 +31,7 @@
 1. Paste left signal high-resolution CSV data.
 2. Paste right signal high-resolution CSV data.
 3. Select the coordinated phase for each signal.
-4. Choose the reference event (start green, start yellow, end yellow).
+4. Choose the reference event (start green, start yellow, beginning of red).
 5. Click Calculate Offsets to review the cycle-by-cycle table.
             </pre>
           </v-expansion-panel-text>
@@ -40,8 +40,8 @@
     </div>
 
     <v-card class="pa-4 mt-6" variant="outlined">
-      <v-row>
-        <v-col cols="12" md="6">
+      <v-row align="center">
+        <v-col cols="12" md="5">
           <h2 class="section-title">Left Signal (Reference)</h2>
           <v-select
             v-model="leftPhase"
@@ -57,7 +57,22 @@
           </div>
         </v-col>
 
-        <v-col cols="12" md="6">
+        <v-col
+          cols="12"
+          md="2"
+          class="d-flex align-center justify-center"
+        >
+          <v-btn
+            color="secondary"
+            variant="outlined"
+            class="swap-button"
+            @click="swapSignals"
+          >
+            &gt;&gt;
+          </v-btn>
+        </v-col>
+
+        <v-col cols="12" md="5">
           <h2 class="section-title">Right Signal (Offset)</h2>
           <v-select
             v-model="rightPhase"
@@ -121,23 +136,28 @@
           <div class="summary-label">Right Cycles Found</div>
           <div class="summary-value">{{ summary.rightCount }}</div>
         </div>
-        <div>
-          <div class="summary-label">Average Offset (s)</div>
-          <div class="summary-value">{{ summary.average }}</div>
-        </div>
-        <div>
-          <div class="summary-label">Median Offset (s)</div>
-          <div class="summary-value">{{ summary.median }}</div>
-        </div>
-        <div>
-          <div class="summary-label">Min Offset (s)</div>
-          <div class="summary-value">{{ summary.min }}</div>
-        </div>
-        <div>
-          <div class="summary-label">Max Offset (s)</div>
-          <div class="summary-value">{{ summary.max }}</div>
-        </div>
       </div>
+
+      <v-table density="compact" class="mt-4">
+        <thead>
+          <tr>
+            <th>Pattern</th>
+            <th>Cycles</th>
+            <th>Average Offset (s)</th>
+            <th>Min Offset (s)</th>
+            <th>Max Offset (s)</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="row in summaryRows" :key="row.pattern">
+            <td>{{ row.pattern }}</td>
+            <td>{{ row.count }}</td>
+            <td>{{ row.average }}</td>
+            <td>{{ row.min }}</td>
+            <td>{{ row.max }}</td>
+          </tr>
+        </tbody>
+      </v-table>
 
       <div class="table-toolbar">
         <div class="table-count">Rows in table: {{ offsetRows.length }}</div>
@@ -150,17 +170,28 @@
         <thead>
           <tr>
             <th>Cycle</th>
+            <th>Pattern</th>
             <th>Left Event Time</th>
             <th>Right Event Time</th>
             <th>Offset (seconds)</th>
+            <th v-for="label in phaseHistoryLabels" :key="label">
+              {{ label }}
+            </th>
           </tr>
         </thead>
         <tbody>
           <tr v-for="row in offsetRows" :key="row.cycle">
             <td>{{ row.cycle }}</td>
+            <td>{{ row.pattern }}</td>
             <td>{{ row.leftTime }}</td>
             <td>{{ row.rightTime }}</td>
             <td>{{ row.offsetSeconds }}</td>
+            <td
+              v-for="(phaseText, index) in row.phaseHistory"
+              :key="`${row.cycle}-${index}`"
+            >
+              {{ phaseText }}
+            </td>
           </tr>
         </tbody>
       </v-table>
@@ -191,20 +222,23 @@ export default {
         count: 0,
         leftCount: 0,
         rightCount: 0,
-        average: "--",
-        median: "--",
-        min: "--",
-        max: "--",
       },
+      summaryRows: [],
       leftTextboxDefault:
         "Paste left signal high-resolution CSV data (timestamp, event code, phase)",
       rightTextboxDefault:
         "Paste right signal high-resolution CSV data (timestamp, event code, phase)",
       phaseOptions: Array.from({ length: 16 }, (_, index) => index + 1),
+      phaseHistoryLabels: [
+        "Prev Phase 1",
+        "Prev Phase 2",
+        "Prev Phase 3",
+        "Prev Phase 4",
+      ],
       eventOptions: [
         { label: "Start of Green (Event 1)", value: 1 },
         { label: "Start of Yellow (Event 8)", value: 8 },
-        { label: "End of Yellow (Event 9)", value: 9 },
+        { label: "Beginning of Red (Event 10)", value: 10 },
       ],
     };
   },
@@ -217,7 +251,16 @@ export default {
     },
   },
   methods: {
-    parseSignalEvents(rawData, phase, eventCode) {
+    swapSignals() {
+      const tempData = this.leftSignalData;
+      this.leftSignalData = this.rightSignalData;
+      this.rightSignalData = tempData;
+
+      const tempPhase = this.leftPhase;
+      this.leftPhase = this.rightPhase;
+      this.rightPhase = tempPhase;
+    },
+    parseRawEvents(rawData) {
       if (!rawData || !rawData.trim()) {
         return [];
       }
@@ -234,12 +277,7 @@ export default {
           const parsedEventCode = Number.parseInt(eventCodeRaw, 10);
           const parsedParameter = Number.parseInt(parameterRaw, 10);
 
-          if (
-            Number.isNaN(parsedEventCode) ||
-            Number.isNaN(parsedParameter) ||
-            parsedEventCode !== eventCode ||
-            parsedParameter !== phase
-          ) {
+          if (Number.isNaN(parsedEventCode) || Number.isNaN(parsedParameter)) {
             return null;
           }
 
@@ -249,6 +287,8 @@ export default {
           }
 
           return {
+            eventCode: parsedEventCode,
+            parameter: parsedParameter,
             humanReadable: timeInfo.humanReadable,
             iso: timeInfo.iso,
             milliseconds: timeInfo.MillisecFromEpoch,
@@ -257,17 +297,131 @@ export default {
         .filter((item) => item)
         .sort((a, b) => a.milliseconds - b.milliseconds);
     },
+    parseSignalEvents(rawEvents, phase, eventCode) {
+      if (!rawEvents.length) {
+        return [];
+      }
+
+      return rawEvents.filter(
+        (event) => event.eventCode === eventCode && event.parameter === phase
+      );
+    },
+    getPatternAtTime(patternChanges, timestamp) {
+      if (!patternChanges.length) {
+        return -1;
+      }
+
+      let selected = -1;
+      for (const change of patternChanges) {
+        if (change.milliseconds <= timestamp) {
+          selected = change.parameter;
+        } else {
+          break;
+        }
+      }
+      return selected;
+    },
+    buildPhaseHistory(rawEvents, leftEvents, index, targetPhase) {
+      const endTime = leftEvents[index].milliseconds;
+      const startTime =
+        index === 0
+          ? Number.NEGATIVE_INFINITY
+          : leftEvents[index - 1].milliseconds;
+
+      const windowEvents = rawEvents.filter(
+        (event) => event.milliseconds > startTime && event.milliseconds < endTime
+      );
+
+      const entries = [];
+      const handledPhases = new Set();
+      const terminationMap = {
+        4: "Gap",
+        5: "Max",
+        6: "Force",
+        14: "Skip",
+      };
+
+      const phaseEventsByPhase = windowEvents.reduce((acc, event) => {
+        if (!acc.has(event.parameter)) {
+          acc.set(event.parameter, []);
+        }
+        acc.get(event.parameter).push(event);
+        return acc;
+      }, new Map());
+
+      const addEntry = (phase, timestamp, servedSeconds, terminationCode) => {
+        if (phase === targetPhase || handledPhases.has(phase)) {
+          return;
+        }
+        handledPhases.add(phase);
+        const terminationLabel = terminationMap[terminationCode] || "Unknown";
+        const servedText =
+          servedSeconds === null || Number.isNaN(servedSeconds)
+            ? "--"
+            : Number(servedSeconds.toFixed(2));
+        entries.push({
+          phase,
+          timestamp,
+          text: `Phase ${phase} (${servedText}) ${terminationLabel}`,
+        });
+      };
+
+      phaseEventsByPhase.forEach((events, phase) => {
+        const starts = events.filter((event) => event.eventCode === 1);
+        if (starts.length) {
+          starts.forEach((startEvent) => {
+            const endEvent = events.find(
+              (event) =>
+                event.milliseconds > startEvent.milliseconds &&
+                [7, 8, 9, 10, 11, 12].includes(event.eventCode)
+            );
+            const servedSeconds = endEvent
+              ? (endEvent.milliseconds - startEvent.milliseconds) / 1000
+              : null;
+            const terminationEvent = [...events]
+              .filter(
+                (event) =>
+                  event.milliseconds > startEvent.milliseconds &&
+                  (!endEvent || event.milliseconds <= endEvent.milliseconds) &&
+                  Object.keys(terminationMap).includes(`${event.eventCode}`)
+              )
+              .pop();
+            addEntry(
+              phase,
+              startEvent.milliseconds,
+              servedSeconds,
+              terminationEvent ? terminationEvent.eventCode : null
+            );
+          });
+        } else {
+          const skipEvent = events.find((event) => event.eventCode === 14);
+          if (skipEvent) {
+            addEntry(phase, skipEvent.milliseconds, 0, 14);
+          }
+        }
+      });
+
+      return entries
+        .sort((a, b) => a.timestamp - b.timestamp)
+        .slice(-this.phaseHistoryLabels.length)
+        .map((entry) => entry.text);
+    },
     calculateOffsets() {
       this.warningMessage = "";
+      const leftRawEvents = this.parseRawEvents(this.leftSignalData);
+      const rightRawEvents = this.parseRawEvents(this.rightSignalData);
       const leftEvents = this.parseSignalEvents(
-        this.leftSignalData,
+        leftRawEvents,
         this.leftPhase,
         this.eventBasis
       );
       const rightEvents = this.parseSignalEvents(
-        this.rightSignalData,
+        rightRawEvents,
         this.rightPhase,
         this.eventBasis
+      );
+      const patternChanges = leftRawEvents.filter(
+        (event) => event.eventCode === 131
       );
 
       const leftCount = leftEvents.length;
@@ -280,11 +434,8 @@ export default {
           count: 0,
           leftCount,
           rightCount,
-          average: "--",
-          median: "--",
-          min: "--",
-          max: "--",
         };
+        this.summaryRows = [];
         this.warningMessage =
           "No matching events were found. Check phase numbers, event selection, and data format.";
         return;
@@ -301,36 +452,64 @@ export default {
         const offsetSeconds =
           (rightEvent.milliseconds - leftEvent.milliseconds) / 1000;
         offsets.push(offsetSeconds);
+        const pattern = this.getPatternAtTime(
+          patternChanges,
+          leftEvent.milliseconds
+        );
+        const phaseHistory = this.buildPhaseHistory(
+          leftRawEvents,
+          leftEvents,
+          index,
+          this.leftPhase
+        );
+        const filledPhaseHistory = [...phaseHistory];
+        while (filledPhaseHistory.length < this.phaseHistoryLabels.length) {
+          filledPhaseHistory.unshift("--");
+        }
         return {
           cycle: index + 1,
+          pattern,
           leftTime: leftEvent.humanReadable,
           rightTime: rightEvent.humanReadable,
           offsetSeconds: Number(offsetSeconds.toFixed(2)),
+          phaseHistory: filledPhaseHistory,
         };
       });
 
-      this.summary = this.buildSummary(offsets, leftCount, rightCount);
+      this.summary = this.buildSummaryCounts(leftCount, rightCount, pairCount);
+      this.summaryRows = this.buildPatternSummary(this.offsetRows);
     },
-    buildSummary(offsets, leftCount, rightCount) {
-      const sorted = [...offsets].sort((a, b) => a - b);
-      const count = sorted.length;
-      const total = sorted.reduce((sum, value) => sum + value, 0);
-      const average = count ? total / count : 0;
-      const median = count
-        ? count % 2 === 0
-          ? (sorted[count / 2 - 1] + sorted[count / 2]) / 2
-          : sorted[Math.floor(count / 2)]
-        : 0;
-
+    buildSummaryCounts(leftCount, rightCount, count) {
       return {
         count,
         leftCount,
         rightCount,
-        average: Number(average.toFixed(2)),
-        median: Number(median.toFixed(2)),
-        min: Number(sorted[0].toFixed(2)),
-        max: Number(sorted[count - 1].toFixed(2)),
       };
+    },
+    buildPatternSummary(rows) {
+      const summaryMap = rows.reduce((acc, row) => {
+        if (!acc.has(row.pattern)) {
+          acc.set(row.pattern, []);
+        }
+        acc.get(row.pattern).push(row.offsetSeconds);
+        return acc;
+      }, new Map());
+
+      return Array.from(summaryMap.entries())
+        .map(([pattern, offsets]) => {
+          const sorted = [...offsets].sort((a, b) => a - b);
+          const count = sorted.length;
+          const total = sorted.reduce((sum, value) => sum + value, 0);
+          const average = count ? total / count : 0;
+          return {
+            pattern,
+            count,
+            average: Number(average.toFixed(2)),
+            min: Number(sorted[0].toFixed(2)),
+            max: Number(sorted[count - 1].toFixed(2)),
+          };
+        })
+        .sort((a, b) => a.pattern - b.pattern);
     },
     exportOffsets() {
       if (!this.offsetRows.length) {
@@ -339,9 +518,11 @@ export default {
 
       const header = [
         "Cycle",
+        "Pattern",
         "Left Event Time",
         "Right Event Time",
         "Offset (seconds)",
+        ...this.phaseHistoryLabels,
       ];
       const escapeCsvValue = (value) => {
         const stringValue = `${value}`;
@@ -352,9 +533,11 @@ export default {
       };
       const bodyRows = this.offsetRows.map((row) => [
         row.cycle,
+        row.pattern,
         row.leftTime,
         row.rightTime,
         row.offsetSeconds,
+        ...row.phaseHistory,
       ]);
       const csvContent = [header, ...bodyRows]
         .map((row) => row.map(escapeCsvValue).join(","))
@@ -412,6 +595,10 @@ export default {
 .table-count {
   font-size: 14px;
   opacity: 0.8;
+}
+
+.swap-button {
+  min-width: 64px;
 }
 
 .grow-wrap {


### PR DESCRIPTION
### Motivation
- Provide per-pattern statistics and show the pattern number for each cycle so analysts can see offsets grouped by controller pattern even when pattern changes occur.
- Replace the `End of Yellow` option with `Beginning of Red` for the offset reference event to match the requested alignment choice.
- Add a swap control to reverse inputs and a phase-history view that reports whether recent phases gapped, maxed, or skipped to aid troubleshooting.

### Description
- Updated the UI layout to add a centered swap button (`>>`) between the left/right input boxes and changed input column widths to accommodate it, plus a small CSS rule for `.swap-button`.
- Replaced the event option `End of Yellow (Event 9)` with `Beginning of Red (Event 10)` in `eventOptions` and updated the help text accordingly.
- Added `parseRawEvents` and adapted `parseSignalEvents` to work from parsed event objects, and implemented `getPatternAtTime` to detect pattern numbers from `eventCode === 131` changes (returns `-1` when unknown).
- Implemented `buildPhaseHistory` to collect the previous N phases (using `phaseHistoryLabels`) with formatted notes like `Phase 1 (20) Gap` using termination event mappings (Gap/Max/Force/Skip) and included this per-row in `offsetRows` as `phaseHistory`.
- Added per-pattern aggregation via `buildPatternSummary` and a new `summaryRows` table that shows `pattern`, `count`, `average`, `min`, and `max` offsets; also added `buildSummaryCounts` to maintain overall counts.
- Extended CSV export to include `Pattern` and the phase-history columns for each row, and updated the offset table to display `Pattern` and the phase-history columns.
- Implemented `swapSignals` method to swap input text and selected phases between left and right signals.

### Testing
- Started the dev server using `npm run dev` and confirmed Vite reported ready (local and network URLs), which succeeded.
- Ran a Playwright script to navigate to `/signal-offsets` and capture a screenshot, which completed successfully and produced an artifact.`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69704a8ffc08832baf40de43b1360622)