### PR TITLE
Add Yellow & Red Light Running tool

### DIFF
--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -163,6 +163,10 @@ export default {
       tools: [
         { title: "Split History", path: "/split-history" },
         { title: "Red Light Runners", path: "/detectorRLR" },
+        {
+          title: "Yellow & Red Light Running Tool",
+          path: "/yellow-red-running",
+        },
         { title: "Timeseries Plot All Enumerations", path: "/preemption-plotter" },
         { title: "Detection Channel Plotter", path: "/detection-plotter" },
         { title: "Delay & Count Estimator", path: "/delay-estimator" },
@@ -188,6 +192,10 @@ export default {
       TSdataTools: [
         { title: "Split History", path: "/split-history" },
         { title: "Red Light Runners", path: "/detectorRLR" },
+        {
+          title: "Yellow & Red Light Running Tool",
+          path: "/yellow-red-running",
+        },
         { title: "Timeseries Plot All Enumerations", path: "/preemption-plotter" },
         { title: "Detection Channel Plotter", path: "/detection-plotter" },
         { title: "Delay & Count Estimator", path: "/delay-estimator" },

--- a/src/components/ProcessYellowRedRunning.vue
+++ b/src/components/ProcessYellowRedRunning.vue
@@ -1,0 +1,292 @@
+<template>
+  <div>
+    <div class="rlr-inputs">
+      <div class="grow-wrap">
+        <InputBox v-model="inputData" :defaultText="dataDefaultText" />
+      </div>
+      <div class="grow-wrap">
+        <InputBox
+          v-model="detectorMapInput"
+          :defaultText="detectorDefaultText"
+        />
+      </div>
+    </div>
+    <div class="actions">
+      <v-btn color="primary" @click="processDetectorEvents">Process</v-btn>
+    </div>
+
+    <div v-if="tableRows.length" class="rlr-table-wrapper">
+      <table class="rlr-table">
+        <thead>
+          <tr>
+            <th>Timestamp</th>
+            <th>Detector</th>
+            <th>Phase</th>
+            <th>Signal State</th>
+            <th>Seconds Into State</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr v-for="row in tableRows" :key="row.key">
+            <td>{{ row.timestamp }}</td>
+            <td>{{ row.detector }}</td>
+            <td>{{ row.phase }}</td>
+            <td>{{ row.state }}</td>
+            <td>{{ formatSeconds(row.elapsedSeconds) }}</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <div v-else-if="hasProcessed" class="no-results">
+      No yellow/red detector-off events were found for the mapped phases.
+    </div>
+  </div>
+</template>
+
+<script>
+import { DateTime } from "luxon";
+import convertTime from "../mixins/convertTime";
+import InputBox from "./foundational/InputBox.vue";
+
+const DISPLAY_FORMAT = "ccc, MMM d yyyy h:mm:ss.S a";
+
+export default {
+  mixins: [convertTime],
+  components: {
+    InputBox,
+  },
+  data() {
+    return {
+      inputData: "",
+      detectorMapInput: "",
+      dataDefaultText:
+        "Paste in High-Resolution Traffic Signal Data as CSV (timestamp, eventCode, channel)",
+      detectorDefaultText: "Det 1\t6\nDet 2\t2\nDet 3\t0\nDet 4\t0\nDet 5\t0",
+      tableRows: [],
+      hasProcessed: false,
+    };
+  },
+  methods: {
+    processDetectorEvents() {
+      const { detectorToPhase, phaseColumns } = this.parseDetectorMapping(
+        this.detectorMapInput
+      );
+      const events = this.parseHighResData(this.inputData);
+      if (!events.length || !phaseColumns.length) {
+        this.tableRows = [];
+        this.hasProcessed = true;
+        return;
+      }
+
+      const phaseIntervals = this.buildSignalIntervals(events, phaseColumns);
+      const rows = events
+        .filter(
+          (event) =>
+            event.eventCode === 81 && detectorToPhase[event.parameterCode]
+        )
+        .map((event) => {
+          const phase = detectorToPhase[event.parameterCode];
+          const interval = this.findInterval(
+            phaseIntervals[phase] || [],
+            event.millis
+          );
+          if (!interval) {
+            return null;
+          }
+          return {
+            key: `${event.millis}-${event.parameterCode}`,
+            timestamp: this.formatMillis(event.millis),
+            detector: event.parameterCode,
+            phase,
+            state: interval.state,
+            elapsedSeconds: (event.millis - interval.start) / 1000,
+          };
+        })
+        .filter((row) => row !== null);
+
+      this.tableRows = rows;
+      this.hasProcessed = true;
+    },
+    parseDetectorMapping(text) {
+      const detectorToPhase = {};
+      const phases = new Set();
+
+      text
+        .split("\n")
+        .map((line) => line.trim())
+        .filter((line) => line)
+        .forEach((line) => {
+          const matches = line.match(/\d+/g);
+          if (!matches || matches.length < 2) {
+            return;
+          }
+          const detector = Number(matches[0]);
+          const phase = Number(matches[1]);
+          if (!Number.isNaN(detector) && phase > 0) {
+            detectorToPhase[detector] = phase;
+            phases.add(phase);
+          }
+        });
+
+      return {
+        detectorToPhase,
+        phaseColumns: Array.from(phases).sort((a, b) => a - b),
+      };
+    },
+    parseHighResData(text) {
+      return text
+        .split("\n")
+        .map((line) => line.trim())
+        .filter((line) => line)
+        .map((line) => {
+          const [timestamp, eventCode, parameter] = line.split(",");
+          const converted = this.convertTimestamp(timestamp?.trim() || "");
+          if (!converted?.MillisecFromEpoch) {
+            return null;
+          }
+          return {
+            millis: converted.MillisecFromEpoch,
+            eventCode: Number(eventCode),
+            parameterCode: Number(parameter),
+          };
+        })
+        .filter((event) => event && !Number.isNaN(event.eventCode))
+        .sort((a, b) => a.millis - b.millis);
+    },
+    buildSignalIntervals(events, phaseColumns) {
+      const phaseState = {};
+      const intervalsByPhase = {};
+
+      phaseColumns.forEach((phase) => {
+        phaseState[phase] = {
+          yellowStart: null,
+          redStart: null,
+          redCandidate: null,
+        };
+        intervalsByPhase[phase] = [];
+      });
+
+      events.forEach((event) => {
+        const phase = event.parameterCode;
+        if (!phaseColumns.includes(phase)) {
+          return;
+        }
+        const state = phaseState[phase];
+
+        if (event.eventCode === 8) {
+          state.yellowStart = event.millis;
+        }
+
+        if (event.eventCode === 9) {
+          if (state.yellowStart !== null) {
+            intervalsByPhase[phase].push({
+              state: "Yellow",
+              start: state.yellowStart,
+              end: event.millis,
+            });
+            state.yellowStart = null;
+          }
+          if (state.redStart === null) {
+            state.redCandidate = event.millis;
+          }
+        }
+
+        if (event.eventCode === 10) {
+          state.redStart = event.millis;
+          state.redCandidate = null;
+        }
+
+        if ([11, 12, 0, 1].includes(event.eventCode)) {
+          const redStart =
+            state.redStart !== null ? state.redStart : state.redCandidate;
+          if (redStart !== null) {
+            intervalsByPhase[phase].push({
+              state: "Red",
+              start: redStart,
+              end: event.millis,
+            });
+            state.redStart = null;
+            state.redCandidate = null;
+          }
+        }
+      });
+
+      return intervalsByPhase;
+    },
+    findInterval(intervals, millis) {
+      return intervals.find(
+        (interval) => millis >= interval.start && millis <= interval.end
+      );
+    },
+    formatMillis(millis) {
+      return DateTime.fromMillis(millis).toFormat(DISPLAY_FORMAT);
+    },
+    formatSeconds(seconds) {
+      const rounded = Math.round(seconds * 10) / 10;
+      return `${rounded.toFixed(1)} sec`;
+    },
+  },
+};
+</script>
+
+<style scoped>
+.rlr-inputs {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 16px;
+}
+
+.actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: center;
+  margin: 16px 0;
+}
+
+.rlr-table-wrapper {
+  overflow-x: auto;
+}
+
+.rlr-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.rlr-table th,
+.rlr-table td {
+  border: 1px solid #ccc;
+  padding: 8px;
+  text-align: left;
+  vertical-align: top;
+}
+
+.no-results {
+  margin-top: 12px;
+  font-style: italic;
+}
+
+.grow-wrap {
+  display: grid;
+}
+
+.grow-wrap::after {
+  content: attr(data-replicated-value) " ";
+  white-space: pre-wrap;
+  visibility: hidden;
+}
+
+.grow-wrap > textarea {
+  resize: none;
+  overflow: hidden;
+  overflow-y: scroll;
+}
+
+.grow-wrap > textarea,
+.grow-wrap::after {
+  border: 1px solid black;
+  padding: 0.5rem;
+  font: inherit;
+  grid-area: 1 / 1 / 2 / 2;
+}
+</style>

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -22,6 +22,7 @@ import MessageSignDesigner from '../views/MessageSignDesigner'
 import Blog from '../views/Blog'
 import StuckDetectors from '../views/StuckDetectors'
 import SignalOffsetCalculator from '../views/SignalOffsetCalculator'
+import YellowRedRunning from '../views/YellowRedRunning'
 
 
 
@@ -111,6 +112,11 @@ const routes = [
         path: '/delay-estimator',
         name: 'delayEstimator',
         component: DelayEstimator,
+    },
+    {
+        path: '/yellow-red-running',
+        name: 'yellowRedRunning',
+        component: YellowRedRunning,
     },
     {
         path: '/stuck-detectors',

--- a/src/seo/routes.js
+++ b/src/seo/routes.js
@@ -119,6 +119,12 @@ export const routeMeta = {
       "Analyze yellow/red light running events from controller and detection data.",
     path: "/detectorRLR",
   },
+  yellowRedRunning: {
+    title: "Yellow & Red Light Running Tool | Detector Off Events",
+    description:
+      "Identify detector-off events that occur during yellow or red intervals for mapped phases.",
+    path: "/yellow-red-running",
+  },
   preemptionPlotter: {
     title: "Preemption Timeseries Plotter | Enumeration Diagnostics",
     description:

--- a/src/views/About.vue
+++ b/src/views/About.vue
@@ -68,6 +68,12 @@ export default {
               path: "/detectorRLR",
             },
             {
+              title: "Yellow & Red Light Running Tool",
+              description:
+                "Match detector-off events to yellow/red intervals by phase.",
+              path: "/yellow-red-running",
+            },
+            {
               title: "Timeseries Plot All Enumerations",
               description:
                 "Plot preemption and event enumerations over time for diagnostics.",

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -58,6 +58,15 @@ export default {
         },
         {
           image:
+            "https://trafficsignalkit.s3.us-east-2.amazonaws.com/Photos/TrafficSignalKit.com-Yellow+and+Red+Light+Running+Detection.png",
+          title: "Yellow & Red Light Running Tool",
+          description:
+            "Detect detector-off events during yellow or red intervals",
+          link: "/yellow-red-running",
+          topics: ["Red Light Running", "Controller Data"],
+        },
+        {
+          image:
             "https://trafficsignalkit.s3.us-east-2.amazonaws.com/Photos/trafficsignalkit.com-high-resolution-controller-data-explainer-ATSPM.png",
           title: "Delay & Count Estimator",
           description: "Estimate detector call delays to phase service",

--- a/src/views/YellowRedRunning.vue
+++ b/src/views/YellowRedRunning.vue
@@ -1,0 +1,46 @@
+<template>
+  <div>
+    &nbsp;
+    <h1 class="h1-center-text">Yellow &amp; Red Light Running Tool</h1>
+
+    <div class="left-justify-text">
+      <v-expansion-panels v-model="panel" multiple>
+        <v-expansion-panel title="About: Yellow &amp; Red Light Running" value="about">
+          <v-expansion-panel-text>
+            This tool reviews detector off events (event 81) and checks whether
+            the associated phase was in yellow or red at that time. It reports
+            the number of seconds into the yellow or red interval for each
+            detector-off event.
+          </v-expansion-panel-text>
+        </v-expansion-panel>
+        <v-expansion-panel title="Example: Using This Tool" value="example">
+          <v-expansion-panel-text>
+            Paste high-resolution controller CSV data in the first box and map
+            detector channels to phases in the second box. Click Process to
+            list detector-off events that occur during yellow or red.
+          </v-expansion-panel-text>
+        </v-expansion-panel>
+      </v-expansion-panels>
+    </div>
+    <br />
+    <ProcessYellowRedRunning />
+  </div>
+</template>
+
+<script>
+import ProcessYellowRedRunning from "../components/ProcessYellowRedRunning.vue";
+
+export default {
+  name: "YellowRedRunning",
+  components: {
+    ProcessYellowRedRunning,
+  },
+  data() {
+    return {
+      panel: [],
+    };
+  },
+};
+</script>
+
+<style scoped></style>


### PR DESCRIPTION
### Motivation
- Provide a focused tool to identify detector-off events that occur while the associated phase is in yellow or red and report how many seconds into that interval the detector turned off. 

### Description
- Add a new processing component `ProcessYellowRedRunning.vue` that parses pasted high-resolution CSV (timestamp,eventCode,parameter), maps detector channels to phases, constructs yellow and red intervals from phase events, finds detector-off events (`81`) for mapped detectors, and computes seconds into the yellow or red interval for each event. 
- Add a new view `YellowRedRunning.vue` and wire it into the app via routing (`src/router/index.js`), navigation (`src/components/Header.vue`), home listing (`src/views/Home.vue`), about listings (`src/views/About.vue`), and SEO metadata (`src/seo/routes.js`).
- Reuse the existing `InputBox` and `convertTime` mixin for timestamp conversion/formatting and display results in a simple table with `Timestamp`, `Detector`, `Phase`, `Signal State`, and `Seconds Into State` columns.

### Testing
- Started the development server with `npm run dev -- --host 0.0.0.0 --port 4173` and confirmed Vite reported the server as `ready` and the root endpoint returned `HTTP/1.1 200 OK`. (success)
- Ran an automated Playwright script that navigated to `http://127.0.0.1:4173/yellow-red-running` and captured a screenshot saved as `artifacts/yellow-red-running.png`, confirming the new page loads in the running dev server. (success)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971143dfd2c832b8fdb042df8a4dd5f)