### PR TITLE
About: use normal browser scrolling for tool directory

### DIFF
--- a/src/views/About.vue
+++ b/src/views/About.vue
@@ -14,7 +14,7 @@
       <v-card class="ma-2 pa-4" elevation="2">
         <v-card-title class="section-title">Tool Directory</v-card-title>
         <v-card-text>
-          <v-list density="compact" class="tool-scroll-list">
+          <v-list density="compact">
             <template v-for="section in sections" :key="section.title">
               <v-list-subheader class="section-title">
                 {{ section.title }}
@@ -173,11 +173,6 @@ export default {
 }
 .section-description {
   margin-bottom: 16px;
-}
-.tool-scroll-list {
-  max-height: 70vh;
-  overflow-y: auto;
-  padding-right: 8px;
 }
 .tool-list-item :deep(.v-list-item-title) {
   font-weight: 500;


### PR DESCRIPTION
### Motivation
- Replace the constrained, scrollable tool list on the About page with normal browser scrolling so the page scrolls naturally.

### Description
- In `src/views/About.vue` removed the `class="tool-scroll-list"` from the `<v-list>` and deleted the corresponding `.tool-scroll-list` CSS block.

### Testing
- Attempted to run the dev server with `npm run dev` and capture a screenshot via Playwright, but the server did not respond and the Playwright run failed with `net::ERR_EMPTY_RESPONSE`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69711913abfc832bb75eeb59089ad1ec)