### PR TITLE
Add GPX elevation summary metrics and display metrics card in Elevation Plotter

### DIFF
--- a/src/components/ProcessGPXElevation.vue
+++ b/src/components/ProcessGPXElevation.vue
@@ -6,6 +6,49 @@
   <v-btn color="primary" @click="btnPlot">Plot</v-btn>
   <v-btn color="info" @click="resetZoom">Reset Zoom</v-btn>
   <br />
+  <v-card v-if="metrics" class="metrics-card">
+    <v-card-title>GPX Summary Metrics</v-card-title>
+    <v-card-text>
+      <div class="metrics-grid">
+        <div class="metric">
+          <span class="metric-label">Total Distance</span>
+          <span class="metric-value">{{ formatDistance(metrics.totalDistanceMiles) }}</span>
+        </div>
+        <div class="metric">
+          <span class="metric-label">Elevation Gain</span>
+          <span class="metric-value">{{ formatFeet(metrics.totalElevationGainFeet) }}</span>
+        </div>
+        <div class="metric">
+          <span class="metric-label">Elevation Loss</span>
+          <span class="metric-value">{{ formatFeet(metrics.totalElevationLossFeet) }}</span>
+        </div>
+        <div class="metric">
+          <span class="metric-label">Avg Speed</span>
+          <span class="metric-value">{{ formatSpeed(metrics.averageSpeedMph) }}</span>
+        </div>
+        <div class="metric">
+          <span class="metric-label">Avg Uphill Speed</span>
+          <span class="metric-value">{{ formatSpeed(metrics.averageUphillSpeedMph) }}</span>
+        </div>
+        <div class="metric">
+          <span class="metric-label">Avg Downhill Speed</span>
+          <span class="metric-value">{{ formatSpeed(metrics.averageDownhillSpeedMph) }}</span>
+        </div>
+        <div class="metric">
+          <span class="metric-label">Min Elevation</span>
+          <span class="metric-value">{{ formatFeet(metrics.minElevationFeet) }}</span>
+        </div>
+        <div class="metric">
+          <span class="metric-label">Max Elevation</span>
+          <span class="metric-value">{{ formatFeet(metrics.maxElevationFeet) }}</span>
+        </div>
+        <div class="metric">
+          <span class="metric-label">Elapsed Time</span>
+          <span class="metric-value">{{ formatDuration(metrics.totalTimeSeconds) }}</span>
+        </div>
+      </div>
+    </v-card-text>
+  </v-card>
   <canvas ref="scatterPlotCanvas"></canvas>
   <br />
 
@@ -48,17 +91,54 @@ export default {
   data() {
     return {
       gpxTextboxDefaultText: "Paste in GPX file in XML format",
-      inputData: ""
+      inputData: "",
+      metrics: null
     };
   },
   methods: {
     btnPlot() {
-      const pts = this.processGPXElevation(this.inputData);
-      this.renderElevationChart(pts);
+      const result = this.processGPXElevation(this.inputData);
+      this.metrics = result.metrics;
+      this.renderElevationChart(result.dataset);
     },
     copyLatLon(point) {
       const text = `${point.lat.toFixed(5)}, ${point.lon.toFixed(5)}`
       navigator.clipboard?.writeText(text)
+    },
+    formatDistance(distanceMiles) {
+      if (distanceMiles === null || distanceMiles === undefined) {
+        return "—";
+      }
+      return `${distanceMiles.toFixed(2)} mi`;
+    },
+    formatFeet(value) {
+      if (value === null || value === undefined) {
+        return "—";
+      }
+      return `${value.toFixed(0)} ft`;
+    },
+    formatSpeed(value) {
+      if (value === null || value === undefined) {
+        return "—";
+      }
+      return `${value.toFixed(1)} mph`;
+    },
+    formatDuration(totalSeconds) {
+      if (!totalSeconds) {
+        return "—";
+      }
+      const hours = Math.floor(totalSeconds / 3600);
+      const minutes = Math.floor((totalSeconds % 3600) / 60);
+      const seconds = Math.floor(totalSeconds % 60);
+      const parts = [];
+      if (hours > 0) {
+        parts.push(`${hours}h`);
+      }
+      if (minutes > 0 || hours > 0) {
+        parts.push(`${minutes}m`);
+      }
+      parts.push(`${seconds}s`);
+      return parts.join(" ");
     }
   }
 };
@@ -67,5 +147,37 @@ export default {
 <style scoped>
 .grow-wrap > textarea {
   height: 200px;
+}
+
+.metrics-card {
+  margin: 16px 0;
+}
+
+.metrics-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 12px 24px;
+}
+
+.metric {
+  display: flex;
+  flex-direction: column;
+  padding: 8px 12px;
+  border-radius: 8px;
+  background: rgba(30, 139, 195, 0.08);
+}
+
+.metric-label {
+  font-size: 0.85rem;
+  color: #4b5563;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.metric-value {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: #0f172a;
+  margin-top: 4px;
 }
 </style>

--- a/src/mixins/processElevation.js
+++ b/src/mixins/processElevation.js
@@ -40,26 +40,100 @@ export default {
       const gpx = new gpxParser()
       gpx.parse(gpxText)
       if (!gpx.tracks || gpx.tracks.length === 0) {
-        return []
+        return { dataset: [], metrics: null }
       }
       const pts = gpx.tracks[0].points
       const dataset = []
       let cumDist = 0
+      let totalGain = 0
+      let totalLoss = 0
+      let totalTimeSeconds = 0
+      let uphillDistance = 0
+      let downhillDistance = 0
+      let uphillTime = 0
+      let downhillTime = 0
+      let minElevation = Number.POSITIVE_INFINITY
+      let maxElevation = Number.NEGATIVE_INFINITY
+      let previousElevation = null
+
       for (let i = 0; i < pts.length; i++) {
+        const eleFt = pts[i].ele ? pts[i].ele * 3.28084 : 0
+        if (eleFt < minElevation) {
+          minElevation = eleFt
+        }
+        if (eleFt > maxElevation) {
+          maxElevation = eleFt
+        }
+
         if (i > 0) {
           const p1 = [pts[i - 1].lat, pts[i - 1].lon]
           const p2 = [pts[i].lat, pts[i].lon]
-          cumDist += this.earthDistance(p1, p2, false)
+          const segmentDistance = this.earthDistance(p1, p2, false)
+          cumDist += segmentDistance
+
+          if (previousElevation !== null) {
+            const deltaElevation = eleFt - previousElevation
+            if (deltaElevation > 0) {
+              totalGain += deltaElevation
+            } else if (deltaElevation < 0) {
+              totalLoss += Math.abs(deltaElevation)
+            }
+
+            if (pts[i].time && pts[i - 1].time) {
+              const timeDelta =
+                (new Date(pts[i].time).getTime() -
+                  new Date(pts[i - 1].time).getTime()) /
+                1000
+              if (timeDelta > 0) {
+                totalTimeSeconds += timeDelta
+                if (deltaElevation > 0) {
+                  uphillDistance += segmentDistance
+                  uphillTime += timeDelta
+                } else if (deltaElevation < 0) {
+                  downhillDistance += segmentDistance
+                  downhillTime += timeDelta
+                }
+              }
+            }
+          }
         }
-        const eleFt = pts[i].ele ? pts[i].ele * 3.28084 : 0
+
         dataset.push({
           x: cumDist,
           y: eleFt,
           lat: pts[i].lat,
           lon: pts[i].lon
         })
+        previousElevation = eleFt
       }
-      return dataset
+
+      const totalDistanceMiles = cumDist / 5280
+      const averageSpeedMph =
+        totalTimeSeconds > 0
+          ? totalDistanceMiles / (totalTimeSeconds / 3600)
+          : null
+      const averageUphillSpeedMph =
+        uphillTime > 0 ? (uphillDistance / 5280) / (uphillTime / 3600) : null
+      const averageDownhillSpeedMph =
+        downhillTime > 0
+          ? (downhillDistance / 5280) / (downhillTime / 3600)
+          : null
+
+      return {
+        dataset,
+        metrics: {
+          totalDistanceFeet: cumDist,
+          totalDistanceMiles,
+          totalElevationGainFeet: totalGain,
+          totalElevationLossFeet: totalLoss,
+          totalTimeSeconds: totalTimeSeconds || null,
+          averageSpeedMph,
+          averageUphillSpeedMph,
+          averageDownhillSpeedMph,
+          minElevationFeet: Number.isFinite(minElevation) ? minElevation : null,
+          maxElevationFeet: Number.isFinite(maxElevation) ? maxElevation : null
+        }
+      }
     },
     renderElevationChart(dataset) {
       const ctx = this.$refs.scatterPlotCanvas.getContext('2d')


### PR DESCRIPTION
### Motivation
- Provide quick, well-integrated summary metrics (distance, elevation gain/loss, elapsed time, avg speeds, min/max elevation) alongside the elevation profile so users can immediately assess GPX track statistics.

### Description
- Extend `processGPXElevation` to return `{ dataset, metrics }` and compute cumulative distance, total elevation gain/loss, elapsed time, uphill/downhill distances and times, average speeds (overall/uphill/downhill), and min/max elevations in `src/mixins/processElevation.js`.
- Update `ProcessGPXElevation.vue` to consume the new return shape, render a styled metrics card with formatting helpers (`formatDistance`, `formatFeet`, `formatSpeed`, `formatDuration`), and keep the elevation chart rendering using the returned `dataset`.
- Add responsive CSS for a grid-style metrics card so the metrics appear integrated and readable on the elevation plot page.
- Note that the `processGPXElevation` return shape changed from an array to an object with `dataset` and `metrics`, so callers expecting the old array should be updated accordingly.

### Testing
- Ran the dev server with `npm run dev` and confirmed Vite started and served the app on the expected port.
- Used a Playwright script to open `/gpx-elevation`, paste a GPX snippet, click `Plot`, and capture a full-page screenshot (`artifacts/gpx-elevation-metrics.png`), which shows the metrics card and chart; the script completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69711c1dc4c0832b9eb8595acb68f38b)