### PR TITLE
Enhance traffic simulator layout and styling

### DIFF
--- a/src/components/IntersectionSim.vue
+++ b/src/components/IntersectionSim.vue
@@ -1,76 +1,136 @@
 <template>
-  <div>
-    <div>
-      <EventLogger ref="eventLogger" />
-
-      <v-container>
+  <div class="simulator">
+    <v-card class="control-card" elevation="3">
+      <v-card-title>Signal Controls</v-card-title>
+      <v-card-text>
         <v-row>
-          <v-col cols="12" md="6" sm="4">
+          <v-col cols="12" md="6">
             <h5>Minimum Green Time (Seconds)</h5>
-
             <v-number-input
               control-variant="stacked"
               :min="1"
               v-model.number="minGreen"
-            >
-            </v-number-input>
+            />
           </v-col>
 
-          <v-col cols="12" md="6" sm="4">
+          <v-col cols="12" md="6">
             <h5>Maximum Green Time (Seconds)</h5>
-
             <v-number-input
               control-variant="stacked"
               :min="1"
               v-model.number="maxGreen"
-            >
-            </v-number-input>
+            />
           </v-col>
         </v-row>
-        <v-row>
-          <v-col cols="12" md="6" sm="4">
-            <h5>Phase Clock:</h5>
-            <h2>
-              <div v-if="isRunning">{{ phClock }}s</div>
-            </h2>
+        <v-row class="sim-actions" align="center">
+          <v-col cols="12" md="8">
+            <div class="button-row">
+              <v-btn
+                @click="addVehicleEB"
+                color="light-blue-lighten-3"
+                variant="elevated"
+              >
+                Add Vehicle EB
+              </v-btn>
+              <v-btn
+                @click="addVehicleSB"
+                color="brown-lighten-3"
+                variant="elevated"
+              >
+                Add Vehicle SB
+              </v-btn>
+              <v-btn
+                @click="toggleLights(true)"
+                color="light-green-lighten-3"
+                variant="elevated"
+              >
+                Toggle Lights
+              </v-btn>
+            </div>
           </v-col>
-          <v-col cols="12" md="4" sm="4">
-            <h5>Cycle Clock:</h5>
-            <h2>
-              <div v-if="isRunning">{{ cycleClock }}s</div>
-            </h2>
+          <v-col cols="12" md="4">
+            <div class="chip-row">
+              <v-chip color="primary" variant="tonal">
+                Active Phase: {{ getActive("phaseDir") }}
+              </v-chip>
+              <v-chip color="secondary" variant="tonal">
+                Cycle {{ cycleCount }}
+              </v-chip>
+            </div>
           </v-col>
         </v-row>
-      </v-container>
-    </div>
-  </div>
-  <v-btn @click="addVehicleEB" color="light-blue-lighten-3"
-    >Add Vehicle EB</v-btn
-  >&nbsp;
-  <v-btn @click="addVehicleSB" color="brown-lighten-3">Add Vehicle SB</v-btn
-  >&nbsp;
-  <v-btn @click="toggleLights(true)" color="light-green-lighten-3"
-    >Toggle Lights</v-btn
-  >
-  <div class="intersection">
-    <TrafficLight
-      :adjustL="shift350px"
-      :adjustT="shift270px"
-      :position="posAbsolute"
-      :state="sbLightState"
-    />
-    <VehicleLane :vehicles="vehiclesEB" />
+      </v-card-text>
+    </v-card>
 
-    <TrafficLight
-      :rotate="rotate90"
-      :adjustL="shift410px"
-      :adjustT="shift211px"
-      :position="posAbsolute"
-      :state="ebLightState"
-    />
-    <VehicleLaneVert :vehicles="vehiclesSB" />
+    <v-row class="stats-row" dense>
+      <v-col cols="12" md="4">
+        <v-card class="stat-card" elevation="2">
+          <v-card-title>Phase Clock</v-card-title>
+          <v-card-text class="stat-card__value">
+            <span v-if="isRunning">{{ phClock }}s</span>
+          </v-card-text>
+        </v-card>
+      </v-col>
+      <v-col cols="12" md="4">
+        <v-card class="stat-card" elevation="2">
+          <v-card-title>Cycle Clock</v-card-title>
+          <v-card-text class="stat-card__value">
+            <span v-if="isRunning">{{ cycleClock }}s</span>
+          </v-card-text>
+        </v-card>
+      </v-col>
+      <v-col cols="12" md="4">
+        <v-card class="stat-card" elevation="2">
+          <v-card-title>Extension Gap</v-card-title>
+          <v-card-text class="stat-card__value">
+            <span>{{ phGap }}s</span>
+          </v-card-text>
+        </v-card>
+      </v-col>
+    </v-row>
+
+    <v-row class="sim-layout" dense>
+      <v-col cols="12" md="7">
+        <v-card class="stage-card" elevation="3">
+          <v-card-title>Intersection View</v-card-title>
+          <v-card-text>
+            <div class="intersection-stage">
+              <div class="road road--horizontal"></div>
+              <div class="road road--vertical"></div>
+              <div class="crosswalk crosswalk--horizontal"></div>
+              <div class="crosswalk crosswalk--vertical"></div>
+              <div class="intersection">
+                <TrafficLight
+                  :adjustL="shift350px"
+                  :adjustT="shift270px"
+                  :position="posAbsolute"
+                  :state="sbLightState"
+                />
+                <VehicleLane :vehicles="vehiclesEB" />
+
+                <TrafficLight
+                  :rotate="rotate90"
+                  :adjustL="shift410px"
+                  :adjustT="shift211px"
+                  :position="posAbsolute"
+                  :state="ebLightState"
+                />
+                <VehicleLaneVert :vehicles="vehiclesSB" />
+              </div>
+            </div>
+          </v-card-text>
+        </v-card>
+      </v-col>
+      <v-col cols="12" md="5">
+        <v-card class="log-card" elevation="3">
+          <v-card-title>Event History</v-card-title>
+          <v-card-text>
+            <EventLogger ref="eventLogger" />
+          </v-card-text>
+        </v-card>
+      </v-col>
+    </v-row>
   </div>
-  <div class="large-gap"></div>
 </template>
 
 <script>
@@ -326,5 +386,105 @@ export default {
 }
 .large-gap {
   margin-top: 500px; /* Adjust the value as needed */
+}
+
+.simulator {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.control-card,
+.stage-card,
+.log-card,
+.stat-card {
+  border-radius: 18px;
+}
+
+.sim-actions {
+  margin-top: 8px;
+}
+
+.button-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.chip-row {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  align-items: flex-start;
+}
+
+.stats-row {
+  margin-top: 4px;
+}
+
+.stat-card__value {
+  font-size: 1.6rem;
+  font-weight: 600;
+}
+
+.intersection-stage {
+  position: relative;
+  background: linear-gradient(180deg, #f4f7fb 0%, #e7edf5 100%);
+  border-radius: 16px;
+  padding: 24px;
+  overflow: hidden;
+  min-height: 320px;
+}
+
+.road {
+  position: absolute;
+  background: #3b3f46;
+  box-shadow: inset 0 0 0 2px rgba(255, 255, 255, 0.05);
+}
+
+.road--horizontal {
+  top: 50%;
+  left: -10%;
+  width: 120%;
+  height: 90px;
+  transform: translateY(-50%);
+  border-radius: 8px;
+}
+
+.road--vertical {
+  left: 50%;
+  top: -10%;
+  width: 90px;
+  height: 120%;
+  transform: translateX(-50%);
+  border-radius: 8px;
+}
+
+.crosswalk {
+  position: absolute;
+  background: repeating-linear-gradient(
+    90deg,
+    rgba(255, 255, 255, 0.8),
+    rgba(255, 255, 255, 0.8) 10px,
+    transparent 10px,
+    transparent 18px
+  );
+  opacity: 0.6;
+}
+
+.crosswalk--horizontal {
+  width: 120px;
+  height: 16px;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -60px);
+}
+
+.crosswalk--vertical {
+  width: 16px;
+  height: 120px;
+  top: 50%;
+  left: 50%;
+  transform: translate(45px, -50%);
 }
 </style>

--- a/src/components/trafficSim/EventLogger.vue
+++ b/src/components/trafficSim/EventLogger.vue
@@ -29,7 +29,8 @@ export default {
 .log-window {
   border: 1px solid #ccc;
   padding: 10px;
-  width: 600px;
+  width: 100%;
+  max-width: 520px;
   height: 200px;
   overflow-y: auto;
   position: relative;
@@ -38,7 +39,8 @@ export default {
   margin-right: auto;
 
   background-color: white;
-  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 8px 16px rgba(15, 23, 42, 0.08);
+  border-radius: 12px;
 }
 
 .log-messages {

--- a/src/views/TrafficSim.vue
+++ b/src/views/TrafficSim.vue
@@ -1,60 +1,71 @@
 <template>
-  &nbsp;
-  <div>
-    <h1 class="h1-center-text">Gap Out/Max Out Intersection Simulator</h1>
+  <v-container class="sim-page">
+    <v-sheet class="sim-hero" elevation="2">
+      <div class="sim-hero__content">
+        <h1 class="sim-hero__title">Gap Out/Max Out Intersection Simulator</h1>
+        <p class="sim-hero__subtitle">
+          Explore real-world signal timing behavior with an interactive
+          intersection model. Tune timings, add vehicles, and watch how phases
+          end by gap out or max out.
+        </p>
+      </div>
+    </v-sheet>
 
-    <div class="left-justify-text">
-      <v-expansion-panels v-model="panel" multiple>
-        <v-expansion-panel title="About: Intersection Simulator" value="about">
-          <v-expansion-panel-text>
+    <v-row class="sim-info" dense>
+      <v-col cols="12" md="5">
+        <v-card class="sim-info__card" elevation="2">
+          <v-card-title>About the Simulator</v-card-title>
+          <v-card-text>
             Traffic signal events like "gap out" and "max out" are essential
-            concepts in managing intersections. With this simple intersection
-            simulator, you can explore how these events happen and understand
-            their significance.
-          </v-expansion-panel-text>
-        </v-expansion-panel>
+            concepts in managing intersections. With this simulator, you can
+            explore how these events happen and understand their significance.
+          </v-card-text>
+        </v-card>
+      </v-col>
+      <v-col cols="12" md="7">
+        <v-expansion-panels v-model="panel" multiple>
+          <v-expansion-panel
+            title="Detailed Explanation About This Tool"
+            value="detailed-explain"
+          >
+            <v-expansion-panel-text>
+              <b>What is "Gap Out"?</b> "Gap out" occurs when the traffic light
+              changes from green to yellow because there are no vehicles
+              detected in the intersection for a specific period. In simpler
+              terms, the green light ends because the intersection becomes
+              temporarily empty of cars. <br />
+              <u>Example:</u> Imagine a green light at an intersection, and the
+              traffic flows smoothly. If there's a brief moment when no cars
+              are approaching or waiting at the intersection, the traffic
+              signal will "gap out" and transition to yellow, signaling that
+              the green phase is ending. <br />
+              <b>What is "Max Out"?</b> "Max out" happens when the green light
+              duration reaches its maximum limit, regardless of whether there
+              are still cars waiting. This ensures that traffic in the other
+              directions gets a chance to move. <br />
+              <u>Example:</u> Suppose the green light has a maximum duration
+              set to allow traffic to flow smoothly. Even if there are still
+              cars waiting, once this maximum time is reached, the light will
+              "max out," turning yellow to give other directions their turn.
+            </v-expansion-panel-text>
+          </v-expansion-panel>
 
-        <v-expansion-panel
-          title="Detailed Explination About This Tool"
-          value="detailed-explain"
-        >
-          <v-expansion-panel-text>
-            <b>What is "Gap Out"?</b> "Gap out" occurs when the traffic light
-            changes from green to yellow because there are no vehicles detected
-            in the intersection for a specific period. In simpler terms, the
-            green light ends because the intersection becomes temporarily empty
-            of cars. <br />
-            <u>Example:</u> Imagine a green light at an intersection, and the
-            traffic flows smoothly. If there's a brief moment when no cars are
-            approaching or waiting at the intersection, the traffic signal will
-            "gap out" and transition to yellow, signaling that the green phase
-            is ending. <br />
-            <b>What is "Max Out"?</b> "Max out" happens when the green light
-            duration reaches its maximum limit, regardless of whether there are
-            still cars waiting. This ensures that traffic in the other
-            directions gets a chance to move. <br />
-            <u>Example:</u> Suppose the green light has a maximum duration set
-            to allow traffic to flow smoothly. Even if there are still cars
-            waiting, once this maximum time is reached, the light will "max
-            out," turning yellow to give other directions their turn.
-          </v-expansion-panel-text>
-        </v-expansion-panel>
+          <v-expansion-panel title="Example: Using This Tool" value="example">
+            <v-expansion-panel-text>
+              A. Try adding vehicles to a single direction. Notice the light
+              goes green for that phase. <br />B. Try adding vehicles to the
+              opposing phase and see how the intersection gaps out or maxes
+              out. <br />C. Modify the Min and Max times while adding lots of
+              vehicles on both streets. <br />D. Explore the event history to
+              see how long each phase was served.
+            </v-expansion-panel-text>
+          </v-expansion-panel>
+        </v-expansion-panels>
+      </v-col>
+    </v-row>
 
-        <v-expansion-panel title="Example: Using This Tool" value="example">
-          <v-expansion-panel-text>
-            A. Try adding vehicles to a single direction. Notice the light goes
-            green for that phase. <br />B. Try adding vehicles to the opposing
-            phase and see how the intersection gaps out or max's out. <br />C.
-            Modify the Min and Max times while adding lot's of vehicles on both
-            streets. <br />D. Explore the event history to see how long each
-            phase was served.
-          </v-expansion-panel-text>
-        </v-expansion-panel>
-      </v-expansion-panels>
-    </div>
-    <br />
-    <IntersectionSim></IntersectionSim>
-  </div>
+    <IntersectionSim class="sim-core" />
+  </v-container>
 </template>
 
 <script>
@@ -89,4 +100,45 @@ export default {
   },
 };
 </script>
-<style scoped></style>
+<style scoped>
+.sim-page {
+  padding-top: 16px;
+  padding-bottom: 40px;
+}
+
+.sim-hero {
+  padding: 28px 32px;
+  border-radius: 20px;
+  background: linear-gradient(135deg, #0b2b4e 0%, #1c4a7a 45%, #2d6ca3 100%);
+  color: #fff;
+  margin-bottom: 24px;
+}
+
+.sim-hero__content {
+  max-width: 820px;
+}
+
+.sim-hero__title {
+  font-size: clamp(1.8rem, 2.6vw, 2.6rem);
+  font-weight: 700;
+  margin-bottom: 8px;
+}
+
+.sim-hero__subtitle {
+  font-size: 1rem;
+  opacity: 0.9;
+  margin: 0;
+}
+
+.sim-info {
+  margin-bottom: 24px;
+}
+
+.sim-info__card {
+  border-radius: 16px;
+}
+
+.sim-core {
+  margin-top: 8px;
+}
+</style>


### PR DESCRIPTION
### Motivation
- Improve the visual presentation so the Gap Out/Max Out simulator looks and feels more like an interactive simulator. 
- Preserve and continue to surface explanations for "gap out" and "max out" while making the UI easier to scan and interact with.

### Description
- Reworked the `TrafficSim` view to add a hero/header, move explanatory content into a card/expansion-panel layout, and provide a more polished page structure and styles. 
- Reorganized `IntersectionSim` into card-based controls, a button action row, stat cards, and a stage card containing the intersection view, while keeping the original simulation logic intact. 
- Added staged intersection visuals (roads and crosswalks) and CSS to improve realism and layout responsiveness. 
- Polished `EventLogger` styling to use responsive width, softer shadow, and rounded corners for consistency with the new layout.

### Testing
- Started the dev server with `npm run dev` and Vite reported the server as ready. 
- Captured a visual smoke test of the simulator page using Playwright navigating to `http://127.0.0.1:4173/#/traffic-sim`, which produced `artifacts/traffic-sim.png` successfully. 
- No automated unit tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69712ab00b44832ba52bf609f351b65e)