### PR TITLE
Add Max Grade Ascended (%) metric to GPX Elevation Plotter

### DIFF
--- a/src/components/ProcessGPXElevation.vue
+++ b/src/components/ProcessGPXElevation.vue
@@ -43,6 +43,10 @@
           <span class="metric-value">{{ formatFeet(metrics.maxElevationFeet) }}</span>
         </div>
         <div class="metric">
+          <span class="metric-label">Max Grade Ascended</span>
+          <span class="metric-value">{{ formatPercent(metrics.maxUphillGradePercent) }}</span>
+        </div>
+        <div class="metric">
           <span class="metric-label">Elapsed Time</span>
           <span class="metric-value">{{ formatDuration(metrics.totalTimeSeconds) }}</span>
         </div>
@@ -122,6 +126,12 @@ export default {
         return "—";
       }
       return `${value.toFixed(1)} mph`;
+    },
+    formatPercent(value) {
+      if (value === null || value === undefined) {
+        return "—";
+      }
+      return `${value.toFixed(1)}%`;
     },
     formatDuration(totalSeconds) {
       if (!totalSeconds) {

--- a/src/mixins/processElevation.js
+++ b/src/mixins/processElevation.js
@@ -52,6 +52,7 @@ export default {
       let downhillDistance = 0
       let uphillTime = 0
       let downhillTime = 0
+      let maxUphillGradePercent = null
       let minElevation = Number.POSITIVE_INFINITY
       let maxElevation = Number.NEGATIVE_INFINITY
       let previousElevation = null
@@ -77,6 +78,15 @@ export default {
               totalGain += deltaElevation
             } else if (deltaElevation < 0) {
               totalLoss += Math.abs(deltaElevation)
+            }
+            if (deltaElevation > 0 && segmentDistance > 0) {
+              const gradePercent = (deltaElevation / segmentDistance) * 100
+              if (
+                maxUphillGradePercent === null ||
+                gradePercent > maxUphillGradePercent
+              ) {
+                maxUphillGradePercent = gradePercent
+              }
             }
 
             if (pts[i].time && pts[i - 1].time) {
@@ -131,7 +141,8 @@ export default {
           averageUphillSpeedMph,
           averageDownhillSpeedMph,
           minElevationFeet: Number.isFinite(minElevation) ? minElevation : null,
-          maxElevationFeet: Number.isFinite(maxElevation) ? maxElevation : null
+          maxElevationFeet: Number.isFinite(maxElevation) ? maxElevation : null,
+          maxUphillGradePercent
         }
       }
     },


### PR DESCRIPTION
### Motivation
- Provide a simple metric that reports the steepest uphill segment as a percentage so users can see the maximum grade ascended on a GPX track.

### Description
- Compute `maxUphillGradePercent` in `processGPXElevation` by evaluating `(deltaElevation / segmentDistance) * 100` for uphill segments and returning it in the `metrics` object in `src/mixins/processElevation.js`.
- Surface the new metric in the elevation summary card by adding a `Max Grade Ascended` metric and a `formatPercent` helper in `src/components/ProcessGPXElevation.vue`.
- Keep existing metrics and chart rendering unchanged; the new metric is `metrics.maxUphillGradePercent` and is displayed with one decimal and a `%` suffix.

### Testing
- Started the dev server with `npm run dev` and ran an automated browser smoke test that navigated to `/gpx-elevation`, pasted a small GPX sample, clicked `Plot`, and captured a screenshot; the Playwright script completed and produced `artifacts/gpx-elevation-max-grade.png` (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69712b4b6cc0832bb4939d6a3769eb0f)