### PR TITLE
Compute max segment slope and update metric label

### DIFF
--- a/src/components/ProcessGPXElevation.vue
+++ b/src/components/ProcessGPXElevation.vue
@@ -43,8 +43,8 @@
           <span class="metric-value">{{ formatFeet(metrics.maxElevationFeet) }}</span>
         </div>
         <div class="metric">
-          <span class="metric-label">Max Grade Ascended</span>
-          <span class="metric-value">{{ formatPercent(metrics.maxUphillGradePercent) }}</span>
+          <span class="metric-label">Max Slope (Segment)</span>
+          <span class="metric-value">{{ formatPercent(metrics.maxSegmentGradePercent) }}</span>
         </div>
         <div class="metric">
           <span class="metric-label">Elapsed Time</span>

--- a/src/mixins/processElevation.js
+++ b/src/mixins/processElevation.js
@@ -52,7 +52,7 @@ export default {
       let downhillDistance = 0
       let uphillTime = 0
       let downhillTime = 0
-      let maxUphillGradePercent = null
+      let maxSegmentGradePercent = null
       let minElevation = Number.POSITIVE_INFINITY
       let maxElevation = Number.NEGATIVE_INFINITY
       let previousElevation = null
@@ -79,13 +79,14 @@ export default {
             } else if (deltaElevation < 0) {
               totalLoss += Math.abs(deltaElevation)
             }
-            if (deltaElevation > 0 && segmentDistance > 0) {
+            if (segmentDistance > 0) {
               const gradePercent = (deltaElevation / segmentDistance) * 100
+              const observedGrade = Math.abs(gradePercent)
               if (
-                maxUphillGradePercent === null ||
-                gradePercent > maxUphillGradePercent
+                maxSegmentGradePercent === null ||
+                observedGrade > maxSegmentGradePercent
               ) {
-                maxUphillGradePercent = gradePercent
+                maxSegmentGradePercent = observedGrade
               }
             }
 
@@ -142,7 +143,7 @@ export default {
           averageDownhillSpeedMph,
           minElevationFeet: Number.isFinite(minElevation) ? minElevation : null,
           maxElevationFeet: Number.isFinite(maxElevation) ? maxElevation : null,
-          maxUphillGradePercent
+          maxSegmentGradePercent
         }
       }
     },


### PR DESCRIPTION
### Motivation
- Report the maximum observed slope between any two consecutive GPX points (absolute grade) instead of only tracking uphill-only grades across the file.

### Description
- Change the metric name and calculation in `processGPXElevation` to compute the absolute grade per segment and track `maxSegmentGradePercent` in `src/mixins/processElevation.js`.
- Replace the previous uphill-only comparison with an absolute-value comparison so both climbs and descents contribute to the observed maximum segment slope.
- Update the UI label and binding in `src/components/ProcessGPXElevation.vue` to show `Max Slope (Segment)` and display `metrics.maxSegmentGradePercent`.

### Testing
- Started the dev server with `npm run dev` and the Vite server reported ready on the local network (succeeded). 
- Attempted an automated Playwright end-to-end script to load a sample GPX and capture a screenshot, but the browser run timed out or crashed (failed).
- No unit tests were executed as part of this change (none run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697134189330832b965dc03e6ffe2658)