### PR TITLE
Update yellow/red running summaries and red interval handling

### DIFF
--- a/src/components/ProcessYellowRedRunning.vue
+++ b/src/components/ProcessYellowRedRunning.vue
@@ -16,6 +16,7 @@
     </div>
 
     <div v-if="tableRows.length" class="rlr-table-wrapper">
+      <h2 class="section-title">Phase Summary Table</h2>
       <table class="rlr-table">
         <thead>
           <tr>
@@ -47,30 +48,6 @@
               <button
                 class="sort-button"
                 type="button"
-                @click="setSummarySort('yellowMin')"
-              >
-                Yellow Min
-                <span class="sort-indicator">{{
-                  sortIndicator(summarySort, "yellowMin")
-                }}</span>
-              </button>
-            </th>
-            <th>
-              <button
-                class="sort-button"
-                type="button"
-                @click="setSummarySort('yellowMax')"
-              >
-                Yellow Max
-                <span class="sort-indicator">{{
-                  sortIndicator(summarySort, "yellowMax")
-                }}</span>
-              </button>
-            </th>
-            <th>
-              <button
-                class="sort-button"
-                type="button"
                 @click="setSummarySort('yellowAvg')"
               >
                 Yellow Avg
@@ -95,30 +72,6 @@
               <button
                 class="sort-button"
                 type="button"
-                @click="setSummarySort('redMin')"
-              >
-                Red Min
-                <span class="sort-indicator">{{
-                  sortIndicator(summarySort, "redMin")
-                }}</span>
-              </button>
-            </th>
-            <th>
-              <button
-                class="sort-button"
-                type="button"
-                @click="setSummarySort('redMax')"
-              >
-                Red Max
-                <span class="sort-indicator">{{
-                  sortIndicator(summarySort, "redMax")
-                }}</span>
-              </button>
-            </th>
-            <th>
-              <button
-                class="sort-button"
-                type="button"
                 @click="setSummarySort('redAvg')"
               >
                 Red Avg
@@ -133,12 +86,8 @@
           <tr v-for="row in sortedSummaryRows" :key="row.phase">
             <td>{{ row.phase }}</td>
             <td>{{ row.yellowCount }}</td>
-            <td>{{ formatSecondsOrDash(row.yellowMin) }}</td>
-            <td>{{ formatSecondsOrDash(row.yellowMax) }}</td>
             <td>{{ formatSecondsOrDash(row.yellowAvg) }}</td>
             <td>{{ row.redCount }}</td>
-            <td>{{ formatSecondsOrDash(row.redMin) }}</td>
-            <td>{{ formatSecondsOrDash(row.redMax) }}</td>
             <td>{{ formatSecondsOrDash(row.redAvg) }}</td>
           </tr>
         </tbody>
@@ -146,6 +95,7 @@
     </div>
 
     <div v-if="tableRows.length" class="rlr-table-wrapper">
+      <h2 class="section-title">All Yellow and Red Running Events Table</h2>
       <table class="rlr-table">
         <thead>
           <tr>
@@ -279,17 +229,15 @@ export default {
         return {
           phase,
           yellowCount: yellowStats.count,
-          yellowMin: yellowStats.min,
-          yellowMax: yellowStats.max,
           yellowAvg: yellowStats.avg,
           redCount: redStats.count,
-          redMin: redStats.min,
-          redMax: redStats.max,
           redAvg: redStats.avg,
         };
       });
 
-      return summary;
+      return summary.filter(
+        (row) => row.yellowCount > 0 || row.redCount > 0
+      );
     },
     sortedSummaryRows() {
       return this.sortRows(
@@ -506,7 +454,7 @@ export default {
             intervalsByPhase[phase].push({
               state: "Red",
               start: redStart,
-              end: event.millis,
+              end: event.millis + 6000,
             });
             state.redStart = null;
             state.redCandidate = null;


### PR DESCRIPTION
### Motivation
- Simplify the Phase Summary by removing min/max columns and only showing counts/averages for readability. 
- Ensure detector-off events that occur shortly after all-red are captured by including a small post-all-red window. 
- Add clear labels for the summary and the detailed events table and omit phases with no events to reduce clutter.

### Description
- Added section headings `Phase Summary Table` and `All Yellow and Red Running Events Table` in the template. 
- Removed `yellowMin`, `yellowMax`, `redMin`, and `redMax` columns from the Phase Summary table and the corresponding fields from the computed `summaryRows`. 
- Filtered `summaryRows` to exclude phases where both `yellowCount` and `redCount` are zero. 
- Extended red intervals in `buildSignalIntervals` by adding 6000 ms to the red `end` timestamp to include late detector-off events.

### Testing
- Started the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` and verified the app served the site. 
- Ran a Playwright script to navigate to `/yellow-red-running` and capture a screenshot saved as `artifacts/yellow-red-running-summary.png`, which completed successfully. 
- No unit tests were added or run as this change is UI/logic focused and was validated via the UI screenshot.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971365f9638832b8589cea7e0d116f5)