### PR TITLE
Adjust heatmap binning for shorter Yellow/Red running ranges

### DIFF
--- a/src/components/ProcessYellowRedRunning.vue
+++ b/src/components/ProcessYellowRedRunning.vue
@@ -489,11 +489,15 @@ export default {
         }
       } else {
         mode = "time";
+        const totalMinutes = (maxMillis - minMillis) / (1000 * 60);
         let binMinutes = 60;
-        if (spanHours <= 1) {
+        if (spanHours <= 2) {
           binMinutes = 5;
-        } else if (spanHours <= 2) {
-          binMinutes = 10;
+        } else if (spanHours <= 5) {
+          const targetBins = 24;
+          const rawMinutes = Math.ceil(totalMinutes / targetBins);
+          const rounded = Math.ceil(rawMinutes / 5) * 5;
+          binMinutes = Math.max(10, rounded);
         } else if (spanHours <= 6) {
           binMinutes = 15;
         } else if (spanHours <= 12) {
@@ -551,6 +555,15 @@ export default {
         });
       }
 
+      const rangeLabel =
+        mode === "time"
+          ? `${DateTime.fromMillis(minMillis).toFormat(
+              "MMM d, yyyy h:mm a"
+            )} - ${DateTime.fromMillis(maxMillis).toFormat(
+              "MMM d, yyyy h:mm a"
+            )}`
+          : `${start.toFormat("MMM d, yyyy")} - ${end.toFormat("MMM d, yyyy")}`;
+
       return {
         mode,
         modeLabel,
@@ -558,9 +571,7 @@ export default {
         columns,
         counts,
         maxCount,
-        rangeLabel: `${start.toFormat("MMM d, yyyy")} - ${end.toFormat(
-          "MMM d, yyyy"
-        )}`,
+        rangeLabel,
       };
     },
     heatmapLegendSteps() {


### PR DESCRIPTION
### Motivation
- Improve the heatmap time-binning for the Yellow & Red Light Running tool so short time windows are more useful and readable (5-minute bins for very short spans and roughly 24 bins for slightly longer short spans), and show the precise time range when zoomed into a time window.

### Description
- Updated time-based heatmap bin selection in `src/components/ProcessYellowRedRunning.vue` to compute `totalMinutes` and pick `binMinutes` so that spans ≤ 2 hours use 5-minute bins and spans between 2–5 hours target ≈ 24 bins by computing a rounded bin size (minimum 10 minutes); existing logic for longer spans remains unchanged.
- Aligned bin boundaries from the computed `binMinutes` and preserved labeling cadence via `labelIntervalMinutes` so column labels remain readable.
- Replaced the previous date-only `rangeLabel` with a precise time-range label when `mode === 'time'` so the UI shows the zoomed time window.

### Testing
- Started the dev server with `npm run dev` to load the app and validate no build-time errors occurred (succeeded).
- Attempted an automated UI capture with Playwright to verify the page rendering, but Chromium failed to launch in the container so the screenshot step failed and no UI test result was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69716ebf37e0832bb700a515e71f311b)