### PR TITLE
Relabel Timeseries Plot to "All Enumerations"

### DIFF
--- a/src/components/ProcessPreemptionEvents.vue
+++ b/src/components/ProcessPreemptionEvents.vue
@@ -5,7 +5,7 @@
     </div>
     <div>
       <v-btn @click="processPreemptionEvents" color="primary">
-        Process Preemption Events
+        Process All Enumerations
       </v-btn>
     </div>
   </div>

--- a/src/components/foundational/PlotPreemptionTimeSeries.vue
+++ b/src/components/foundational/PlotPreemptionTimeSeries.vue
@@ -54,7 +54,7 @@ export default {
         return {
           datasets: [
             {
-              label: "Preemption Events",
+              label: "All Enumerations",
               data: [],
               borderColor: "#009688",
               backgroundColor: "#009688",
@@ -66,7 +66,7 @@ export default {
       return {
         datasets: [
           {
-            label: "Preemption Events",
+            label: "All Enumerations",
             data: this.plotData.map((event) => ({
               x: event.timestampMs,
               y: this.eventLookup[event.eventCode] ?? `Event ${event.eventCode}`,

--- a/src/views/HighResPreemptionPlotter.vue
+++ b/src/views/HighResPreemptionPlotter.vue
@@ -5,22 +5,19 @@
 
     <div class="left-justify-text">
       <v-expansion-panels v-model="panel" multiple>
-        <v-expansion-panel title="About: Preemption Events" value="about">
+        <v-expansion-panel title="About: All Enumerations" value="about">
           <v-expansion-panel-text>
-            Preemption events (enumerations 101-119) capture the sequence of
-            controller actions when an emergency vehicle, railroad, or other
-            priority request forces the signal out of its normal operation. This
-            tool filters the preemption-related enumerations from high
-            resolution controller data and plots them on a time series so you
-            can see when each stage of the preemption occurred.
+            This tool plots the enumeration values from high resolution
+            controller data on a time series so you can see when each event
+            occurred.
           </v-expansion-panel-text>
         </v-expansion-panel>
 
         <v-expansion-panel title="What This Tool Shows" value="details">
           <v-expansion-panel-text>
             <ul>
-              <li>Timeline of preemption event codes 101-119</li>
-              <li>Event labels for each preemption stage</li>
+              <li>Timeline of enumeration event codes</li>
+              <li>Event labels for each enumeration</li>
               <li>Channel values captured with each event</li>
             </ul>
           </v-expansion-panel-text>
@@ -35,8 +32,7 @@
 16764339645, 105, 1
 16764339705, 111, 1
             </pre>
-            Click <b>Process Preemption Events</b> to plot the preemption event
-            timeline.
+            Click <b>Process All Enumerations</b> to plot the event timeline.
           </v-expansion-panel-text>
         </v-expansion-panel>
       </v-expansion-panels>


### PR DESCRIPTION
### Motivation
- Remove preemption-specific wording from the Timeseries Plot UI so the tool is presented generically for all enumeration events.
- Ensure the processing button and chart labeling reflect the generic "All Enumerations" scope instead of referencing preemption-only events.

### Description
- Updated `src/views/HighResPreemptionPlotter.vue` to change the expansion panel title and explanatory copy to reference "All Enumerations" and a generic description of the plot.
- Rewrote the details list in the same view to say "Timeline of enumeration event codes" and "Event labels for each enumeration" and updated the example call-to-action to "Process All Enumerations".
- Changed the processing button label in `src/components/ProcessPreemptionEvents.vue` to `Process All Enumerations`.
- Renamed the chart dataset label from "Preemption Events" to "All Enumerations" in `src/components/foundational/PlotPreemptionTimeSeries.vue` so legends and empty-state text reflect the new name.

### Testing
- Launched the local dev server with `npm run dev -- --host 0.0.0.0 --port 4173`, which started the vite server (process launched). 
- Attempted an automated UI screenshot with Playwright which failed due to the browser process crashing (`TargetClosedError` / `SIGSEGV`), so visual verification via Playwright did not complete. No unit/integration tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971702cc2d8832bba7c08d983978254)