### PR TITLE
Filter zero-detector phases from yellow/red summary

### DIFF
--- a/src/components/ProcessYellowRedRunning.vue
+++ b/src/components/ProcessYellowRedRunning.vue
@@ -490,6 +490,9 @@ export default {
           const yellowStats = this.computeStats(yellowRows);
           const redStats = this.computeStats(redRows);
           const detectorOffCount = signal.detectorOffCounts[phase] || 0;
+          if (detectorOffCount === 0) {
+            return;
+          }
           const yellowPerDetector =
             detectorOffCount > 0 ? yellowStats.count / detectorOffCount : null;
           const redPerDetector =


### PR DESCRIPTION
### Motivation
- Omit phase summary rows in the Yellow & Red Light Running tool when a phase has zero mapped detector off counts, as those rows are not meaningful.

### Description
- Add a guard in the `summaryRows` computed property of `src/components/ProcessYellowRedRunning.vue` to skip pushing summary entries when `detectorOffCount === 0`.

### Testing
- Started the dev server with `npm run dev` which reported Vite ready, then attempted an end-to-end page load and screenshot using Playwright which failed to load the page (`net::ERR_EMPTY_RESPONSE`), so UI verification was not completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69717724df6c832b938c64325ca92c14)