### PR TITLE
Show yellow/red per-detector as % and add Severity Score to Phase Summary

### DIFF
--- a/src/components/ProcessYellowRedRunning.vue
+++ b/src/components/ProcessYellowRedRunning.vue
@@ -165,7 +165,7 @@
                 type="button"
                 @click="setSummarySort('yellowPerDetector')"
               >
-                Yellow/Det Off
+                Yellow/Det Off %
                 <span class="sort-indicator">{{
                   sortIndicator(summarySort, "yellowPerDetector")
                 }}</span>
@@ -177,9 +177,21 @@
                 type="button"
                 @click="setSummarySort('redPerDetector')"
               >
-                Red/Det Off
+                Red/Det Off %
                 <span class="sort-indicator">{{
                   sortIndicator(summarySort, "redPerDetector")
+                }}</span>
+              </button>
+            </th>
+            <th>
+              <button
+                class="sort-button"
+                type="button"
+                @click="setSummarySort('severityScore')"
+              >
+                Severity Score
+                <span class="sort-indicator">{{
+                  sortIndicator(summarySort, "severityScore")
                 }}</span>
               </button>
             </th>
@@ -198,8 +210,9 @@
             <td>{{ row.redCount }}</td>
             <td>{{ formatSecondsOrDash(row.redAvg) }}</td>
             <td>{{ row.detectorOffCount }}</td>
-            <td>{{ formatRatioOrDash(row.yellowPerDetector) }}</td>
-            <td>{{ formatRatioOrDash(row.redPerDetector) }}</td>
+            <td>{{ formatPercentOrDash(row.yellowPerDetector) }}</td>
+            <td>{{ formatPercentOrDash(row.redPerDetector) }}</td>
+            <td>{{ formatScoreOrDash(row.severityScore) }}</td>
           </tr>
         </tbody>
       </table>
@@ -494,9 +507,13 @@ export default {
             return;
           }
           const yellowPerDetector =
-            detectorOffCount > 0 ? yellowStats.count / detectorOffCount : null;
+            detectorOffCount > 0
+              ? (yellowStats.count / detectorOffCount) * 100
+              : null;
           const redPerDetector =
-            detectorOffCount > 0 ? redStats.count / detectorOffCount : null;
+            detectorOffCount > 0 ? (redStats.count / detectorOffCount) * 100 : null;
+          const severityScore =
+            redStats.avg !== null ? redStats.avg * redStats.count : null;
 
           summary.push({
             signalId: signal.id,
@@ -510,6 +527,7 @@ export default {
             detectorOffCount,
             yellowPerDetector,
             redPerDetector,
+            severityScore,
           });
         });
       });
@@ -1083,11 +1101,17 @@ export default {
       }
       return this.formatSeconds(seconds);
     },
-    formatRatioOrDash(value) {
+    formatPercentOrDash(value) {
       if (value === null || value === undefined) {
         return "—";
       }
-      return value.toFixed(2);
+      return `${value.toFixed(1)}%`;
+    },
+    formatScoreOrDash(value) {
+      if (value === null || value === undefined) {
+        return "—";
+      }
+      return value.toFixed(1);
     },
     heatmapCount(rowKey, columnKey) {
       return this.heatmapConfig.counts.get(`${rowKey}-${columnKey}`) || 0;


### PR DESCRIPTION
### Motivation
- Present per-detector yellow/red metrics as percentages for easier comparison across phases and detectors.
- Surface a simple Severity Score that combines average red duration and event frequency to help prioritize resources.

### Description
- Changed the Phase Summary table headers to show `Yellow/Det Off %` and `Red/Det Off %` and added a new sortable `Severity Score` column.
- Converted `yellowPerDetector` and `redPerDetector` to percentage values by multiplying the ratio by 100 and included the value in the summary rows.
- Added `severityScore` computed as `redStats.avg * redStats.count` (null-safe) and included it in the pushed summary objects and table rendering.
- Added formatting helpers `formatPercentOrDash` and `formatScoreOrDash` and updated the table to use them for the new percentage and score columns.

### Testing
- Started the dev server with `npm run dev` and verified the app served at `http://127.0.0.1:4173/` (succeeded).
- Verified the UI by capturing a page screenshot with Playwright after the server was up; the screenshot capture succeeded after an initial network error on the first attempt.
- Performed an HTTP check with `curl -I http://127.0.0.1:4173/` which returned `200 OK` (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971790d1160832ba22e4444315dd65c)