### PR TITLE
Hide zero-count rows in yellow/red summary table

### DIFF
--- a/src/components/ProcessYellowRedRunning.vue
+++ b/src/components/ProcessYellowRedRunning.vue
@@ -506,6 +506,9 @@ export default {
           if (detectorOffCount === 0) {
             return;
           }
+          if (yellowStats.count === 0 && redStats.count === 0) {
+            return;
+          }
           const yellowPerDetector =
             detectorOffCount > 0
               ? (yellowStats.count / detectorOffCount) * 100


### PR DESCRIPTION
### Motivation
- Reduce noise in the Phase Summary Table by omitting phase rows that have no Yellow or Red events reported.

### Description
- Add an early-return check in the `summaryRows` computed property in `src/components/ProcessYellowRedRunning.vue` to skip phases where `yellowStats.count === 0 && redStats.count === 0` so those rows are not pushed into the summary.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69717bbafe94832b9ff0ffe0a695425f)