### PR TITLE
Highlight clear stuck detector results with green border/background

### DIFF
--- a/src/components/ProcessStuckDetectors.vue
+++ b/src/components/ProcessStuckDetectors.vue
@@ -26,7 +26,10 @@
       <em v-if="hasProcessed">No stuck detectors found after processing data.</em>
       <em v-else>Paste data and click process to find stuck detectors.</em>
     </div>
-    <div v-if="hasProcessed" class="analysis-summary">
+    <div
+      v-if="hasProcessed"
+      :class="['analysis-summary', { 'analysis-summary--clear': !tableItems.length }]"
+    >
       <p>{{ analysisSummary }}</p>
     </div>
   </div>
@@ -208,6 +211,13 @@ export default {
 .analysis-summary {
   margin-top: 16px;
   color: rgba(var(--v-theme-on-surface), 0.8);
+}
+
+.analysis-summary--clear {
+  border: 2px solid #2e7d32;
+  border-radius: 8px;
+  padding: 12px;
+  background: rgba(46, 125, 50, 0.08);
 }
 
 .analysis-summary p {


### PR DESCRIPTION
### Motivation
- Visually indicate a successful/clear analysis by surrounding the analysis summary with a green highlight when no stuck detectors are found.

### Description
- In `src/components/ProcessStuckDetectors.vue` add a conditional class binding on the analysis summary (`:class="['analysis-summary', { 'analysis-summary--clear': !tableItems.length }]"`) and introduce the `.analysis-summary--clear` CSS rule to apply a green border, rounded corners, padding, and a light green background.

### Testing
- Started the app with `npm run dev` and attempted an end-to-end check with a Playwright script, but the Vite server reported unresolved imports (`html2canvas`, `jspdf`, `jspdf-autotable`) and the Playwright run timed out/crashed, so the automated verification did not complete successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971ae0d588c832ba4012635a1135e20)