### PR TITLE
Add Pedestrian Investigator card to home

### DIFF
--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -67,6 +67,15 @@ export default {
         },
         {
           image:
+            "https://trafficsignalkit.s3.us-east-2.amazonaws.com/Photos/TrafficSignalkit.com+-+Vehicle+and+Pedestrian+Delay.png",
+          title: "Pedestrian Investigator",
+          description:
+            "Summarize pedestrian walk, clearance, and crossing distance estimates.",
+          link: "/pedestrian-investigator",
+          topics: ["Controller Data", "Pedestrians", "Diagnostics"],
+        },
+        {
+          image:
             "https://trafficsignalkit.s3.us-east-2.amazonaws.com/Photos/TrafficSignalKit.com+-+Inductance_detectors.jpg",
           title: "Stuck Detector Finder",
           description:


### PR DESCRIPTION
### Motivation
- Expose the existing Pedestrian Investigator tool on the homepage so users can navigate to it from the main card list.

### Description
- Inserted a new `posts` entry in `src/views/Home.vue` with `title: "Pedestrian Investigator"`, `link: "/pedestrian-investigator"`, `description`, `image`, and `topics` fields. 
- The new card reuses the vehicle/pedestrian delay image and categorizes the tool under `Controller Data`, `Pedestrians`, and `Diagnostics`.
- No other view or routing changes were required because the route for `/pedestrian-investigator` already exists.

### Testing
- Launched the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` and confirmed Vite served the app (`VITE ... ready` and local URL printed).
- Captured a homepage screenshot via a Playwright script and verified the new card appears; screenshot saved as `artifacts/home-pedestrian-card.png` and the run completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971b5c7c478832b85bfa148163f19f4)