### PR TITLE
Add risk score column to Pedestrian Investigator summary

### DIFF
--- a/src/views/PedestrianInvestigator.vue
+++ b/src/views/PedestrianInvestigator.vue
@@ -53,6 +53,7 @@
             <th>Avg Walk Time (s)</th>
             <th>Avg Walk Change Interval (s)</th>
             <th>Avg Call-to-Walk Delay (s)</th>
+            <th>Risk Score</th>
             <th>Estimated Crossing Distance (ft)</th>
             <th>Estimated Lanes</th>
           </tr>
@@ -67,6 +68,7 @@
             <td>{{ formatSeconds(row.averageWalkTime) }}</td>
             <td>{{ formatSeconds(row.averageChangeInterval) }}</td>
             <td>{{ formatSeconds(row.averageCallToWalkDelay) }}</td>
+            <td>{{ formatRisk(row.riskScore) }}</td>
             <td>{{ formatDistance(row.estimatedDistance) }}</td>
             <td>{{ formatLanes(row.estimatedLanes) }}</td>
           </tr>
@@ -76,8 +78,10 @@
         Walk and change interval averages use the controller event timestamps
         (0.1-second resolution). Estimated distance uses 3.5 ft/sec multiplied
         by the average walk change interval. Estimated lanes use a 12-foot lane
-        width. Full-service cycles count unique walk cycles in which every
-        phase with a pedestrian call is served without repeats.
+        width. Risk score is calculated as (avg walk change interval + avg
+        call-to-walk delay) × ped calls per hour. Full-service cycles count
+        unique walk cycles in which every phase with a pedestrian call is served
+        without repeats.
       </p>
     </div>
   </div>
@@ -313,6 +317,11 @@ export default {
             durationHours && durationHours > 0
               ? stats.callCount / durationHours
               : null;
+          const riskScore = this.calculateRiskScore({
+            averageChangeInterval,
+            averageCallToWalkDelay,
+            pedCallsPerHour,
+          });
           const fullServiceCallPercent = stats.callCount
             ? (stats.fullServiceCallCount / stats.callCount) * 100
             : null;
@@ -332,6 +341,7 @@ export default {
             averageWalkTime,
             averageChangeInterval,
             averageCallToWalkDelay,
+            riskScore,
             estimatedDistance,
             estimatedLanes,
           };
@@ -396,6 +406,12 @@ export default {
       }
       return value.toFixed(1);
     },
+    formatRisk(value) {
+      if (value === null || value === undefined) {
+        return "-";
+      }
+      return value.toFixed(2);
+    },
     formatDistance(value) {
       if (value === null || value === undefined) {
         return "-";
@@ -419,6 +435,25 @@ export default {
         return "-";
       }
       return value.toFixed(1);
+    },
+    calculateRiskScore({
+      averageChangeInterval,
+      averageCallToWalkDelay,
+      pedCallsPerHour,
+    }) {
+      if (
+        averageChangeInterval === null ||
+        averageChangeInterval === undefined ||
+        averageCallToWalkDelay === null ||
+        averageCallToWalkDelay === undefined ||
+        pedCallsPerHour === null ||
+        pedCallsPerHour === undefined
+      ) {
+        return null;
+      }
+      return (
+        (averageChangeInterval + averageCallToWalkDelay) * pedCallsPerHour
+      );
     },
   },
 };


### PR DESCRIPTION
### Motivation

- Provide a simple prioritization metric for pedestrian crossings by combining observed timing and demand into a single risk score to help identify crossings that may need attention.

### Description

- Add a `Risk Score` column to the Walk Phase Summary table in `src/views/PedestrianInvestigator.vue` and update the summary note to document the calculation. 
- Compute and include `riskScore` in each summary row by calling a new `calculateRiskScore` method that uses `averageChangeInterval`, `averageCallToWalkDelay`, and `pedCallsPerHour`. 
- Add a `formatRisk` helper for display formatting and wire the new field into the template and `summaryRows` construction. 

### Testing

- Started the development server with `npm run dev` and confirmed the app served pages successfully. 
- Rendered the Pedestrian Investigator page and captured a screenshot using Playwright to verify the new column renders, and the script completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971c2c10560832bb5d82b5cc35a293d)