### PR TITLE
Add multi-file CSV upload toggle, header normalization, and loading UI

### DIFF
--- a/src/components/CSVInput.vue
+++ b/src/components/CSVInput.vue
@@ -30,7 +30,13 @@
           />
         </div>
         <div class="file-list">
-          <p v-if="!selectedFileNames.length" class="file-placeholder">
+          <p v-if="isLoadingFiles" class="file-placeholder">
+            Loading files...
+          </p>
+          <p
+            v-else-if="!selectedFileNames.length"
+            class="file-placeholder"
+          >
             No files selected yet.
           </p>
           <ul v-else>
@@ -360,6 +366,7 @@ export default {
       this.selectedFileNames = files.map((file) => file.name);
       const combinedLines = [];
       let headerLine = null;
+      let normalizedHeader = null;
 
       try {
         for (const file of files) {
@@ -373,10 +380,12 @@ export default {
           }
           if (!headerLine) {
             headerLine = lines[0];
+            normalizedHeader = this.normalizeHeader(headerLine);
             combinedLines.push(...lines);
             continue;
           }
-          if (lines[0] === headerLine) {
+          const currentHeader = this.normalizeHeader(lines[0]);
+          if (currentHeader === normalizedHeader) {
             combinedLines.push(...lines.slice(1));
           } else {
             combinedLines.push(...lines);
@@ -387,6 +396,12 @@ export default {
         this.filesLoaded = combinedLines.length > 0;
         this.isLoadingFiles = false;
       }
+    },
+    normalizeHeader(line) {
+      if (!line) {
+        return "";
+      }
+      return line.replace(/^\uFEFF/, "").trim().toLowerCase();
     },
     async processCSV() {
       this.isProcessing = true;


### PR DESCRIPTION
### Motivation
- Provide an alternative to pasting CSV text by letting users upload multiple CSV files via a toggle so tools can accept `FileList` input. 
- Prevent duplicate header rows when concatenating multiple CSV files and give users feedback while files are being read.

### Description
- Added a file upload toggle and drag/drop file input UI controlled by `useFileUpload` and `fileInput`, and display selected filenames via `selectedFileNames`.
- Added `isLoadingFiles` UI state with a `Loading files...` placeholder and kept the process button disabled until files are loaded via the existing `canProcess` computed property.
- Implemented `loadCsvFiles(fileList)` improvements to read file contents, concatenate lines, and skip duplicate headers by normalizing headers with a new `normalizeHeader()` helper.
- Kept `processCSV()` unchanged to read from the aggregated `inputData` and process rows in chunks as before.

### Testing
- Started the dev server with `npm run dev` and Vite reported `ready` and local network URLs (server started successfully). 
- Attempted an automated Playwright UI check that tried to toggle the upload switch and capture a screenshot, but the Playwright run crashed/timed out (browser SIGSEGV / timeout), so the UI check failed. 
- No unit tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971c282f170832b9ccac7b15d2fa917)