### PR TITLE
Update InputBox to use modelValue v-model contract

### DIFF
--- a/src/components/foundational/InputBox.vue
+++ b/src/components/foundational/InputBox.vue
@@ -33,22 +33,38 @@
 <script>
 export default {
   props: {
+    modelValue: {
+      type: String,
+      default: "",
+    },
     defaultText: {
       type: String,
       default: "Paste in text for processing",
     },
   },
+  emits: ["update:modelValue"],
   data() {
     return {
       inputMode: "text",
-      inputData: this.defaultText,
-      textData: this.defaultText,
-      hasFocused: false,
+      inputData: this.modelValue || this.defaultText,
+      textData: this.modelValue || this.defaultText,
+      hasFocused: this.modelValue !== "" && this.modelValue !== this.defaultText,
     };
+  },
+  watch: {
+    modelValue(newValue) {
+      if (newValue === this.inputData) {
+        return;
+      }
+      this.inputData = newValue;
+      if (this.inputMode === "text") {
+        this.hasFocused = this.inputData !== "" && this.inputData !== this.defaultText;
+      }
+    },
   },
   methods: {
     emitInput() {
-      this.$emit("update:inputData", this.inputData);
+      this.$emit("update:modelValue", this.inputData);
     },
     clearText() {
       if (this.inputMode !== "text") {
@@ -78,7 +94,7 @@ export default {
       const files = Array.from(event.target.files || []);
       if (files.length === 0) {
         this.inputData = "";
-        this.emitInput();
+        this.$emit("update:modelValue", this.inputData);
         return;
       }
       Promise.all(
@@ -94,11 +110,11 @@ export default {
       )
         .then((contents) => {
           this.inputData = contents.filter(Boolean).join("\n");
-          this.emitInput();
+          this.$emit("update:modelValue", this.inputData);
         })
         .catch(() => {
           this.inputData = "";
-          this.emitInput();
+          this.$emit("update:modelValue", this.inputData);
         });
     },
   },


### PR DESCRIPTION
### Motivation
- Align `InputBox` with the Vue 3 default `v-model` contract so parent components can bind via `v-model` and receive combined uploaded-file contents reliably.
- Ensure multiple-file uploads produce a single string value that flows to consumers via the standard `update:modelValue` event.

### Description
- Add a `modelValue` prop (`String`, default `""`) and declare `emits: ["update:modelValue"]` on the component.
- Initialize local state (`inputData`, `textData`, and `hasFocused`) from `modelValue` so the component reflects external bindings on mount.
- Add a `watch` on `modelValue` to keep the internal `inputData` and `hasFocused` in sync when the parent updates the model.
- Replace all `update:inputData` emissions with `this.$emit("update:modelValue", newValue)` and ensure file uploads join multiple files with `"\n"` and emit the combined content.

### Testing
- No automated tests were run for this change (no test commands executed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697303a581bc832ba28568c1e02c4d15)