### PR TITLE
Improve Video Frame Extractor layout and add FPS estimation

### DIFF
--- a/src/views/VideoFrameExtractor.vue
+++ b/src/views/VideoFrameExtractor.vue
@@ -3,31 +3,32 @@
     <h1>Video Frame Extractor</h1>
 
     <section class="controls">
-      <label class="control">
+      <label class="control full-width">
         <span>Select a video</span>
         <input type="file" accept="video/*" @change="handleFileChange" />
       </label>
 
-      <div class="control">
-        <label>
-          Frame number
-          <input v-model.number="frameNumber" type="number" min="0" />
-        </label>
-      </div>
+      <label class="control">
+        <span>Frame number</span>
+        <input v-model.number="frameNumber" type="number" min="0" />
+      </label>
 
-      <div class="control">
-        <label>
-          FPS
-          <input v-model.number="fps" type="number" min="1" step="1" />
-        </label>
-      </div>
+      <label class="control">
+        <span>FPS</span>
+        <input v-model.number="fps" type="number" min="1" step="1" />
+      </label>
 
-      <div class="control">
+      <div class="control info">
         <p>
           Target time:
           <strong>{{ formattedTargetTime }}</strong>
         </p>
-        <button type="button" @click="extractFrame" :disabled="!canExtract">
+        <button
+          class="action-button"
+          type="button"
+          @click="extractFrame"
+          :disabled="!canExtract"
+        >
           Extract frame
         </button>
       </div>
@@ -39,7 +40,9 @@
     <section class="preview" v-if="frameDataUrl">
       <h2>Preview</h2>
       <img :src="frameDataUrl" alt="Extracted video frame preview" />
-      <a :href="frameDataUrl" download="frame.png">Download frame</a>
+      <a class="download-button" :href="frameDataUrl" download="frame.png">
+        Download frame
+      </a>
     </section>
   </div>
 </template>
@@ -92,6 +95,7 @@ export default {
 
         const onLoadedMetadata = () => {
           this.updateCanvasSize();
+          this.estimateVideoFps();
           video.removeEventListener("loadedmetadata", onLoadedMetadata);
         };
 
@@ -128,6 +132,62 @@ export default {
       video.addEventListener("seeked", onSeeked, { once: true });
       video.currentTime = this.targetTime;
     },
+    estimateVideoFps() {
+      const video = this.$refs.video;
+      if (!video || typeof video.requestVideoFrameCallback !== "function") {
+        return;
+      }
+
+      video.muted = true;
+      video.playsInline = true;
+
+      const maxSamples = 5;
+      const deltas = [];
+      let lastMediaTime = null;
+
+      const finish = () => {
+        if (!deltas.length) {
+          return;
+        }
+        const averageDelta =
+          deltas.reduce((total, delta) => total + delta, 0) / deltas.length;
+        const estimatedFps = Math.round(1 / averageDelta);
+        if (Number.isFinite(estimatedFps) && estimatedFps > 0) {
+          this.fps = estimatedFps;
+        }
+        video.pause();
+        video.currentTime = 0;
+      };
+
+      const captureFrame = (now, metadata) => {
+        if (lastMediaTime !== null) {
+          const delta = metadata.mediaTime - lastMediaTime;
+          if (delta > 0) {
+            deltas.push(delta);
+          }
+        }
+        lastMediaTime = metadata.mediaTime;
+
+        if (deltas.length >= maxSamples) {
+          finish();
+          return;
+        }
+
+        video.requestVideoFrameCallback(captureFrame);
+      };
+
+      const startSampling = () => {
+        video.currentTime = 0;
+        video.requestVideoFrameCallback(captureFrame);
+      };
+
+      const playPromise = video.play();
+      if (playPromise && typeof playPromise.then === "function") {
+        playPromise.then(startSampling).catch(startSampling);
+      } else {
+        startSampling();
+      }
+    },
     revokeObjectUrl() {
       if (this.objectUrl) {
         URL.revokeObjectURL(this.objectUrl);
@@ -149,30 +209,114 @@ export default {
 .controls {
   display: grid;
   gap: 16px;
-  max-width: 480px;
+  max-width: 640px;
+  padding: 20px;
+  border-radius: 16px;
+  background: rgba(0, 150, 136, 0.08);
+  border: 1px solid rgba(0, 150, 136, 0.35);
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.08);
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
 }
 
 .control {
   display: flex;
   flex-direction: column;
   gap: 8px;
+  font-weight: 600;
+  color: #1f2d2a;
+}
+
+.control input[type="file"],
+.control input[type="number"] {
+  padding: 10px 12px;
+  border-radius: 10px;
+  border: 1px solid rgba(0, 0, 0, 0.15);
+  background: #ffffff;
+  font-size: 0.95rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.control input[type="file"]:focus,
+.control input[type="number"]:focus {
+  outline: none;
+  border-color: #009688;
+  box-shadow: 0 0 0 3px rgba(0, 150, 136, 0.2);
+}
+
+.control.full-width {
+  grid-column: 1 / -1;
+}
+
+.control.info {
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.control.info p {
+  margin: 0;
+  font-weight: 500;
+  color: #2b3b39;
+}
+
+.action-button {
+  align-self: flex-start;
+  padding: 10px 18px;
+  border-radius: 999px;
+  border: none;
+  background: linear-gradient(135deg, #009688, #00796b);
+  color: #ffffff;
+  font-weight: 600;
+  letter-spacing: 0.2px;
+  cursor: pointer;
+  box-shadow: 0 8px 16px rgba(0, 150, 136, 0.3);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.action-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+  box-shadow: none;
+}
+
+.action-button:not(:disabled):hover {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 20px rgba(0, 150, 136, 0.35);
 }
 
 .frame-canvas {
-  margin-top: 16px;
-  max-width: 100%;
-  border: 1px solid #ccc;
+  display: none;
 }
 
 .preview {
   margin-top: 24px;
   display: grid;
   gap: 12px;
+  max-width: 640px;
 }
 
 .preview img {
   max-width: 100%;
-  border: 1px solid #ccc;
+  border-radius: 12px;
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.15);
+}
+
+.download-button {
+  justify-self: start;
+  padding: 10px 18px;
+  border-radius: 999px;
+  text-decoration: none;
+  background: #ffffff;
+  border: 1px solid rgba(0, 150, 136, 0.5);
+  color: #00796b;
+  font-weight: 600;
+  box-shadow: 0 8px 16px rgba(0, 150, 136, 0.15);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.download-button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 20px rgba(0, 150, 136, 0.2);
 }
 
 .visually-hidden {


### PR DESCRIPTION
### Motivation
- Make the Video Frame Extractor controls and buttons visually align with the app theme and improve usability. 
- Auto-detect the source video's frame rate to prefill the FPS field and make time/frame calculations easier for users. 
- Simplify the preview area so the extracted frame is shown once with a clear download action and the working canvas is hidden.

### Description
- Restyled the controls: wider card-like control area, responsive grid layout, upgraded inputs, and a teal-themed rounded `action-button` for extraction. 
- File input is now full-width and frame/FPS inputs are presented as compact controls with improved focus styles. 
- Hides the working canvas (`.frame-canvas`) from the UI and displays a single extracted preview image with a styled `download-button` below it. 
- Added `estimateVideoFps()` which uses `requestVideoFrameCallback`, mutes the video and samples a few frames to compute an estimated FPS and prepopulate `fps`, and integrated it to run after `loadedmetadata`. 
- Minor UX tweaks: set `video.playsInline`, safer video playback sampling, and maintained existing frame extraction logic that draws to the canvas and produces `frameDataUrl`.

### Testing
- Started the dev server with `npm run dev` and confirmed Vite reported the site ready at `http://localhost:4173/` (succeeded). 
- Captured a visual smoke test of the updated page using a Playwright script which navigated to `#/video-frame-extractor` and saved a screenshot artifact (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69750f59bb4c832b818f40ac02bff27e)