### PR TITLE
Use InputBox, tighten dashboard layout, and make Detector-to-Phase mapping collapsible

### DIFF
--- a/src/components/foundational/PlotDetectionTimeSeries.vue
+++ b/src/components/foundational/PlotDetectionTimeSeries.vue
@@ -1,30 +1,31 @@
 <template>
-  <br />
-  <v-card class="mapping-card" variant="outlined">
-    <v-card-title>Detector-to-Phase Alignment</v-card-title>
-    <v-card-text>
-      <v-row>
-        <v-col cols="12" md="7">
-          <v-textarea
-            v-model="mappingInput"
-            :placeholder="mappingPlaceholder"
-            label="Detector-to-Phase Table"
-            rows="6"
-            class="mapping-textarea"
-          ></v-textarea>
-        </v-col>
-        <v-col cols="12" md="5">
-          <div class="alignment-toggle">
-            <div class="alignment-label">Sort rows by</div>
-            <v-btn-toggle v-model="alignmentMode" color="primary" mandatory>
-              <v-btn value="channels">Detection</v-btn>
-              <v-btn value="phases">Phase</v-btn>
-            </v-btn-toggle>
-          </div>
-        </v-col>
-      </v-row>
-    </v-card-text>
-  </v-card>
+  <v-expansion-panels class="mapping-card" variant="accordion">
+    <v-expansion-panel>
+      <v-expansion-panel-title>Detector-to-Phase Alignment</v-expansion-panel-title>
+      <v-expansion-panel-text>
+        <v-row>
+          <v-col cols="12" md="7">
+            <v-textarea
+              v-model="mappingInput"
+              :placeholder="mappingPlaceholder"
+              label="Detector-to-Phase Table"
+              rows="6"
+              class="mapping-textarea"
+            ></v-textarea>
+          </v-col>
+          <v-col cols="12" md="5">
+            <div class="alignment-toggle">
+              <div class="alignment-label">Sort rows by</div>
+              <v-btn-toggle v-model="alignmentMode" color="primary" mandatory>
+                <v-btn value="channels">Detection</v-btn>
+                <v-btn value="phases">Phase</v-btn>
+              </v-btn-toggle>
+            </div>
+          </v-col>
+        </v-row>
+      </v-expansion-panel-text>
+    </v-expansion-panel>
+  </v-expansion-panels>
   <br />
   <v-btn @click="resetZoom">Reset Zoom</v-btn>
   <br />

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -1,23 +1,21 @@
 <template>
   <div class="dashboard-view">
-    <h1 class="h1-center-text">Signal Data Dashboard</h1>
+    <h1 class="h1-center-text dashboard-title">Signal Data Dashboard</h1>
 
     <div v-if="!dashboardReady" class="input-panel">
-      <v-textarea
+      <InputBox
         v-model="inputData"
-        label="Paste high-resolution signal data"
-        rows="8"
-        variant="outlined"
-        auto-grow
-      ></v-textarea>
-      <v-btn color="primary" class="process-btn" @click="processDashboard">
+        class="dashboard-input"
+        defaultText="Paste high-resolution signal data or upload files"
+      />
+      <v-btn color="primary" class="process-btn" size="small" @click="processDashboard">
         Process
       </v-btn>
     </div>
 
     <div v-else class="dashboard-content">
       <v-card class="status-card" variant="outlined">
-        <v-card-text>
+        <v-card-text class="card-body">
           <v-row align="center" dense>
             <v-col cols="12" md="6">
               <v-select
@@ -26,7 +24,7 @@
                 :items="signals"
                 label="Signal selection"
                 variant="outlined"
-                density="comfortable"
+                density="compact"
               ></v-select>
               <div v-else class="single-signal">
                 <span class="label">Signal:</span>
@@ -46,8 +44,8 @@
       </v-card>
 
       <v-card class="plot-card" variant="outlined">
-        <v-card-title>Detector &amp; Phase Plot</v-card-title>
-        <v-card-text>
+        <v-card-title class="card-title">Detector &amp; Phase Plot</v-card-title>
+        <v-card-text class="card-body">
           <PlotDetectionTimeSeries
             :plotData="detectionEvents"
             :phaseData="phaseEvents"
@@ -58,8 +56,8 @@
       <v-row class="tool-row" dense>
         <v-col cols="12" md="6">
           <v-card class="tool-card" variant="outlined">
-            <v-card-title>Phase &amp; Split Table</v-card-title>
-            <v-card-text>
+            <v-card-title class="card-title">Phase &amp; Split Table</v-card-title>
+            <v-card-text class="card-body">
               <v-table density="compact">
                 <thead>
                   <tr>
@@ -90,8 +88,8 @@
         </v-col>
         <v-col cols="12" md="6">
           <v-card class="tool-card" variant="outlined">
-            <v-card-title>Pedestrian Investigator</v-card-title>
-            <v-card-text>
+            <v-card-title class="card-title">Pedestrian Investigator</v-card-title>
+            <v-card-text class="card-body">
               <div class="pedestrian-summary">
                 <div class="summary-line">
                   <span class="label">Calls observed:</span>
@@ -118,9 +116,10 @@
       </v-row>
 
       <v-card class="tool-card" variant="outlined">
-        <v-card-title>High Resolution Explainer Tool</v-card-title>
-        <v-card-text>
-          <v-table density="compact">
+        <v-card-title class="card-title">High Resolution Explainer Tool</v-card-title>
+        <v-card-text class="card-body">
+          <div class="explainer-table">
+            <v-table density="compact">
             <thead>
               <tr>
                 <th>Timestamp</th>
@@ -180,7 +179,8 @@
                 </td>
               </tr>
             </tbody>
-          </v-table>
+            </v-table>
+          </div>
         </v-card-text>
       </v-card>
     </div>
@@ -189,12 +189,14 @@
 
 <script>
 import PlotDetectionTimeSeries from "../components/foundational/PlotDetectionTimeSeries.vue";
+import InputBox from "../components/foundational/InputBox.vue";
 import convertTime from "../mixins/convertTime";
 import enumerationObj from "../data/enumerations.json";
 
 export default {
   name: "Dashboard",
   components: {
+    InputBox,
     PlotDetectionTimeSeries,
   },
   mixins: [convertTime],
@@ -467,7 +469,12 @@ export default {
 
 <style scoped>
 .dashboard-view {
-  padding: 12px;
+  padding: 8px;
+}
+
+.dashboard-title {
+  font-size: 1.4rem;
+  margin-bottom: 12px;
 }
 
 .input-panel {
@@ -475,7 +482,11 @@ export default {
   margin: 0 auto;
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 8px;
+}
+
+.dashboard-input {
+  width: 100%;
 }
 
 .process-btn {
@@ -485,7 +496,16 @@ export default {
 .status-card,
 .plot-card,
 .tool-card {
-  margin-bottom: 20px;
+  margin-bottom: 12px;
+}
+
+.card-title {
+  font-size: 1rem;
+  padding: 12px 16px 6px;
+}
+
+.card-body {
+  padding: 12px 16px 16px;
 }
 
 .status-row {
@@ -520,6 +540,12 @@ export default {
   font-style: italic;
 }
 
+.explainer-table {
+  max-height: 320px;
+  overflow: auto;
+  font-size: 0.85rem;
+}
+
 .pedestrian-summary {
   display: grid;
   gap: 8px;
@@ -536,7 +562,7 @@ export default {
 }
 
 .filter-row th {
-  padding: 8px 4px;
+  padding: 6px 4px;
 }
 
 @media (max-width: 960px) {


### PR DESCRIPTION
### Motivation
- Replace the large freeform textarea with the shared input component so users can either paste data or upload files in the Signal Data Dashboard.
- Make the Detector-to-Phase alignment input hide by default to reduce visual clutter and only expand when needed.
- Reduce paddings and typography sizes and constrain the explainer table height to keep the dashboard compact and avoid endless page scrolling.

### Description
- Replaced the dashboard textarea with the shared `InputBox` component and added `defaultText` guiding text, importing `InputBox` in `src/views/Dashboard.vue` and wiring it to `inputData`.
- Tightened layout and typography in `src/views/Dashboard.vue` by reducing paddings, card margins, adding `.card-title`/`.card-body` classes, using `density="compact"` for the select, and making the main `Process` button smaller.
- Constrained the High Resolution Explainer table by wrapping it in `.explainer-table` with `max-height: 320px` and smaller font, and reduced filter padding.
- Made the Detector-to-Phase mapping input collapsible by moving the mapping textarea into a Vuetify expansion panel in `src/components/foundational/PlotDetectionTimeSeries.vue` so it is hidden by default.
- Adjusted mapping-card and mapping-textarea styles to match the more compact UI.

### Testing
- Started the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` which completed and served the app successfully.
- Verified the dev server responded with HTTP `200 OK` using `curl -I http://127.0.0.1:4173/` which succeeded.
- Ran a Playwright script that navigated to `/#/dashboard` and captured a screenshot at `artifacts/dashboard-compact.png`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697510be47a8832b91e49a93690a8b7c)