### PR TITLE
Use UTC ISO timestamps in yellow/red export

### DIFF
--- a/src/components/ProcessYellowRedRunning.vue
+++ b/src/components/ProcessYellowRedRunning.vue
@@ -924,7 +924,7 @@ export default {
       if (!Number.isFinite(millis)) {
         return "";
       }
-      return DateTime.fromMillis(millis).toISO();
+      return DateTime.fromMillis(millis).toUTC().toISO();
     },
     downloadDetailCsv() {
       if (!this.sortedTableRows.length) {


### PR DESCRIPTION
### Motivation
- Ensure exported CSV timestamps for Yellow & Red running events are canonical UTC ISO-8601 with a trailing `Z`; no Codex skills were used because this is a small in-file change.

### Description
- Update `formatIsoTimestamp` in `src/components/ProcessYellowRedRunning.vue` to call `.toUTC().toISO()` so exported CSV timestamps include the trailing `Z` (UTC) instead of local-offset ISO strings.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69751568ea98832bbb851b98c2255889)