### PR TITLE
Add "Go to Dashboard" CTA on Home page

### DIFF
--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -10,6 +10,11 @@
         Click that heart button to vote on features and shape the future of
         these tools.
       </v-card-text>
+      <v-card-actions class="intro-actions">
+        <v-btn color="primary" variant="flat" to="/dashboard">
+          Go to Dashboard
+        </v-btn>
+      </v-card-actions>
     </v-card>
 
     <h1 class="h1-center-text">Traffic Signal Kit</h1>
@@ -244,6 +249,10 @@ export default {
   font-size: 1.05rem;
   line-height: 1.6;
   text-align: left;
+}
+.intro-actions {
+  justify-content: center;
+  padding-bottom: 20px;
 }
 .left-justify-text {
   margin: 0;


### PR DESCRIPTION
### Motivation
- Provide an obvious call-to-action on the front page so users can quickly navigate to the Dashboard.

### Description
- Added a centered "Go to Dashboard" button under the intro text in `src/views/Home.vue` and added an `.intro-actions` style to center and space the actions row.

### Testing
- Started the dev server with `npm run dev` (Vite reported ready) and captured a screenshot via Playwright (`artifacts/home-dashboard-button.png`) to verify the button renders, both steps succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69751dd9d8b4832b909908005a522b07)