### PR TITLE
Move termination reasons to right column and make split history scrollable

### DIFF
--- a/src/components/foundational/TableDisplaySplit.vue
+++ b/src/components/foundational/TableDisplaySplit.vue
@@ -3,72 +3,6 @@
     <v-window v-model="tab">
       <v-window-item value="table-view">
         <div>
-          <table>
-            <thead>
-              <tr>
-                <th>Termination Reason</th>
-                <th v-for="phase in 8" :key="phase">Phase {{ phase }}</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td>Gap Out</td>
-                <td>{{ processedMetrics.gapOutPercent1 }}%</td>
-                <td>{{ processedMetrics.gapOutPercent2 }}%</td>
-                <td>{{ processedMetrics.gapOutPercent3 }}%</td>
-                <td>{{ processedMetrics.gapOutPercent4 }}%</td>
-                <td>{{ processedMetrics.gapOutPercent5 }}%</td>
-                <td>{{ processedMetrics.gapOutPercent6 }}%</td>
-                <td>{{ processedMetrics.gapOutPercent7 }}%</td>
-                <td>{{ processedMetrics.gapOutPercent8 }}%</td>
-              </tr>
-              <tr>
-                <td>Max Out</td>
-                <td>{{ processedMetrics.maxOutPercent1 }}%</td>
-                <td>{{ processedMetrics.maxOutPercent2 }}%</td>
-                <td>{{ processedMetrics.maxOutPercent3 }}%</td>
-                <td>{{ processedMetrics.maxOutPercent4 }}%</td>
-                <td>{{ processedMetrics.maxOutPercent5 }}%</td>
-                <td>{{ processedMetrics.maxOutPercent6 }}%</td>
-                <td>{{ processedMetrics.maxOutPercent7 }}%</td>
-                <td>{{ processedMetrics.maxOutPercent8 }}%</td>
-              </tr>
-              <tr>
-                <td>Force Off</td>
-                <td>{{ processedMetrics.forceOffPercent1 }}%</td>
-                <td>{{ processedMetrics.forceOffPercent2 }}%</td>
-                <td>{{ processedMetrics.forceOffPercent3 }}%</td>
-                <td>{{ processedMetrics.forceOffPercent4 }}%</td>
-                <td>{{ processedMetrics.forceOffPercent5 }}%</td>
-                <td>{{ processedMetrics.forceOffPercent6 }}%</td>
-                <td>{{ processedMetrics.forceOffPercent7 }}%</td>
-                <td>{{ processedMetrics.forceOffPercent8 }}%</td>
-              </tr>
-              <tr>
-                <td>Skipped</td>
-                <td>{{ processedMetrics.skippedPercent1 }}%</td>
-                <td>{{ processedMetrics.skippedPercent2 }}%</td>
-                <td>{{ processedMetrics.skippedPercent3 }}%</td>
-                <td>{{ processedMetrics.skippedPercent4 }}%</td>
-                <td>{{ processedMetrics.skippedPercent5 }}%</td>
-                <td>{{ processedMetrics.skippedPercent6 }}%</td>
-                <td>{{ processedMetrics.skippedPercent7 }}%</td>
-                <td>{{ processedMetrics.skippedPercent8 }}%</td>
-              </tr>
-              <tr>
-                <td>Total Count</td>
-                <td>{{ processedMetrics.totalPhaseCalls1 }}</td>
-                <td>{{ processedMetrics.totalPhaseCalls2 }}</td>
-                <td>{{ processedMetrics.totalPhaseCalls3 }}</td>
-                <td>{{ processedMetrics.totalPhaseCalls4 }}</td>
-                <td>{{ processedMetrics.totalPhaseCalls5 }}</td>
-                <td>{{ processedMetrics.totalPhaseCalls6 }}</td>
-                <td>{{ processedMetrics.totalPhaseCalls7 }}</td>
-                <td>{{ processedMetrics.totalPhaseCalls8 }}</td>
-              </tr>
-            </tbody>
-          </table>
-          <br /><br />
           <div class="split-history-controls">
             <v-btn
               color="primary"
@@ -79,103 +13,104 @@
               Download CSV (Excel)
             </v-btn>
           </div>
-          <br />
-          <table>
-            <thead>
-              <tr class="split-history-filter-row">
-                <th>
-                  <input
-                    v-model="filters.timestamp"
-                    type="text"
-                    placeholder="Filter timestamp"
-                    aria-label="Filter start timestamp"
-                  />
-                </th>
-                <th>
-                  <input
-                    v-model="filters.cycle"
-                    type="text"
-                    placeholder="Filter cycle"
-                    aria-label="Filter cycle length"
-                  />
-                </th>
-                <th>
-                  <input
-                    v-model="filters.phase"
-                    type="text"
-                    placeholder="Filter phase"
-                    aria-label="Filter phase"
-                  />
-                </th>
-                <th>
-                  <input
-                    v-model="filters.duration"
-                    type="text"
-                    placeholder="Filter duration"
-                    aria-label="Filter duration"
-                  />
-                </th>
-                <th>
-                  <input
-                    v-model="filters.termination"
-                    type="text"
-                    placeholder="Filter termination"
-                    aria-label="Filter termination reason"
-                  />
-                </th>
-              </tr>
-              <tr>
-                <th>Start Timestamp</th>
-                <th>#/Cycle Length</th>
-                <th>Phase</th>
-                <th>Duration (G/Y/AR)</th>
-                <th>Phase Termination Reason</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr
-                v-for="(row, index) in filteredRows"
-                :key="`employee-${index}`"
-              >
-                <td v-html="highlightMatches(row.timestampStart, filters.timestamp)"></td>
-                <td
-                  v-html="
-                    highlightMatches(
-                      `${String(row.cycleCount)} / ${truncateToOneDecimal(
-                        row.cycleLength
-                      )}`,
-                      filters.cycle
-                    )
-                  "
-                ></td>
-                <td
-                  v-html="
-                    highlightMatches(`Phase ${String(row.phase)}`, filters.phase)
-                  "
-                ></td>
-                <td
-                  v-html="
-                    highlightMatches(
-                      `${truncateToOneDecimal(
-                        row.duration
-                      )} (${truncateToOneDecimal(
-                        row.greenTime
-                      )}/${truncateToOneDecimal(
-                        row.yellowTime
-                      )}/${truncateToOneDecimal(row.allRedTime)})`
-                      ,
-                      filters.duration
-                    )
-                  "
-                ></td>
-                <td
-                  v-html="
-                    highlightMatches(row.termReason, filters.termination)
-                  "
-                ></td>
-              </tr>
-            </tbody>
-          </table>
+          <div class="split-history-scroll">
+            <table>
+              <thead>
+                <tr class="split-history-filter-row">
+                  <th>
+                    <input
+                      v-model="filters.timestamp"
+                      type="text"
+                      placeholder="Filter timestamp"
+                      aria-label="Filter start timestamp"
+                    />
+                  </th>
+                  <th>
+                    <input
+                      v-model="filters.cycle"
+                      type="text"
+                      placeholder="Filter cycle"
+                      aria-label="Filter cycle length"
+                    />
+                  </th>
+                  <th>
+                    <input
+                      v-model="filters.phase"
+                      type="text"
+                      placeholder="Filter phase"
+                      aria-label="Filter phase"
+                    />
+                  </th>
+                  <th>
+                    <input
+                      v-model="filters.duration"
+                      type="text"
+                      placeholder="Filter duration"
+                      aria-label="Filter duration"
+                    />
+                  </th>
+                  <th>
+                    <input
+                      v-model="filters.termination"
+                      type="text"
+                      placeholder="Filter termination"
+                      aria-label="Filter termination reason"
+                    />
+                  </th>
+                </tr>
+                <tr>
+                  <th>Start Timestamp</th>
+                  <th>#/Cycle Length</th>
+                  <th>Phase</th>
+                  <th>Duration (G/Y/AR)</th>
+                  <th>Phase Termination Reason</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr
+                  v-for="(row, index) in filteredRows"
+                  :key="`employee-${index}`"
+                >
+                  <td v-html="highlightMatches(row.timestampStart, filters.timestamp)"></td>
+                  <td
+                    v-html="
+                      highlightMatches(
+                        `${String(row.cycleCount)} / ${truncateToOneDecimal(
+                          row.cycleLength
+                        )}`,
+                        filters.cycle
+                      )
+                    "
+                  ></td>
+                  <td
+                    v-html="
+                      highlightMatches(`Phase ${String(row.phase)}`, filters.phase)
+                    "
+                  ></td>
+                  <td
+                    v-html="
+                      highlightMatches(
+                        `${truncateToOneDecimal(
+                          row.duration
+                        )} (${truncateToOneDecimal(
+                          row.greenTime
+                        )}/${truncateToOneDecimal(
+                          row.yellowTime
+                        )}/${truncateToOneDecimal(row.allRedTime)})`
+                        ,
+                        filters.duration
+                      )
+                    "
+                  ></td>
+                  <td
+                    v-html="
+                      highlightMatches(row.termReason, filters.termination)
+                    "
+                  ></td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
         </div>
       </v-window-item>
     </v-window>
@@ -248,60 +183,6 @@ export default {
         duration: this.truncateToOneDecimal(row.duration),
         termReason: row.termReason,
       }));
-    },
-    processedMetrics() {
-      if (this.isDataLoaded()) {
-        let maxLength = this.tableData.length - 1;
-
-        let phaseData = this.tableData[maxLength];
-
-        console.log(phaseData);
-
-        return {
-          gapOutPercent1: phaseData.gapOutPercents[0],
-          gapOutPercent2: phaseData.gapOutPercents[1],
-          gapOutPercent3: phaseData.gapOutPercents[2],
-          gapOutPercent4: phaseData.gapOutPercents[3],
-          gapOutPercent5: phaseData.gapOutPercents[4],
-          gapOutPercent6: phaseData.gapOutPercents[5],
-          gapOutPercent7: phaseData.gapOutPercents[6],
-          gapOutPercent8: phaseData.gapOutPercents[7],
-          maxOutPercent1: phaseData.maxOutPercents[0],
-          maxOutPercent2: phaseData.maxOutPercents[1],
-          maxOutPercent3: phaseData.maxOutPercents[2],
-          maxOutPercent4: phaseData.maxOutPercents[3],
-          maxOutPercent5: phaseData.maxOutPercents[4],
-          maxOutPercent6: phaseData.maxOutPercents[5],
-          maxOutPercent7: phaseData.maxOutPercents[6],
-          maxOutPercent8: phaseData.maxOutPercents[7],
-          forceOffPercent1: phaseData.forceOffPercents[0],
-          forceOffPercent2: phaseData.forceOffPercents[1],
-          forceOffPercent3: phaseData.forceOffPercents[2],
-          forceOffPercent4: phaseData.forceOffPercents[3],
-          forceOffPercent5: phaseData.forceOffPercents[4],
-          forceOffPercent6: phaseData.forceOffPercents[5],
-          forceOffPercent7: phaseData.forceOffPercents[6],
-          forceOffPercent8: phaseData.forceOffPercents[7],
-          skippedPercent1: phaseData.skippedPercents[0],
-          skippedPercent2: phaseData.skippedPercents[1],
-          skippedPercent3: phaseData.skippedPercents[2],
-          skippedPercent4: phaseData.skippedPercents[3],
-          skippedPercent5: phaseData.skippedPercents[4],
-          skippedPercent6: phaseData.skippedPercents[5],
-          skippedPercent7: phaseData.skippedPercents[6],
-          skippedPercent8: phaseData.skippedPercents[7],
-          totalPhaseCalls1: phaseData.totalPhaseCalls[0],
-          totalPhaseCalls2: phaseData.totalPhaseCalls[1],
-          totalPhaseCalls3: phaseData.totalPhaseCalls[2],
-          totalPhaseCalls4: phaseData.totalPhaseCalls[3],
-          totalPhaseCalls5: phaseData.totalPhaseCalls[4],
-          totalPhaseCalls6: phaseData.totalPhaseCalls[5],
-          totalPhaseCalls7: phaseData.totalPhaseCalls[6],
-          totalPhaseCalls8: phaseData.totalPhaseCalls[7],
-        };
-      } else {
-        return "";
-      }
     },
   },
   methods: {
@@ -393,6 +274,12 @@ export default {
   flex-wrap: wrap;
   gap: 12px;
   align-items: center;
+}
+
+.split-history-scroll {
+  max-height: 360px;
+  overflow: auto;
+  margin-top: 12px;
 }
 
 .split-history-filter-row input {

--- a/src/components/foundational/TerminationReasonTable.vue
+++ b/src/components/foundational/TerminationReasonTable.vue
@@ -1,0 +1,151 @@
+<template>
+  <v-card-text>
+    <div v-if="processedMetrics">
+      <table>
+        <thead>
+          <tr>
+            <th>Termination Reason</th>
+            <th v-for="phase in 8" :key="phase">Phase {{ phase }}</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Gap Out</td>
+            <td>{{ processedMetrics.gapOutPercent1 }}%</td>
+            <td>{{ processedMetrics.gapOutPercent2 }}%</td>
+            <td>{{ processedMetrics.gapOutPercent3 }}%</td>
+            <td>{{ processedMetrics.gapOutPercent4 }}%</td>
+            <td>{{ processedMetrics.gapOutPercent5 }}%</td>
+            <td>{{ processedMetrics.gapOutPercent6 }}%</td>
+            <td>{{ processedMetrics.gapOutPercent7 }}%</td>
+            <td>{{ processedMetrics.gapOutPercent8 }}%</td>
+          </tr>
+          <tr>
+            <td>Max Out</td>
+            <td>{{ processedMetrics.maxOutPercent1 }}%</td>
+            <td>{{ processedMetrics.maxOutPercent2 }}%</td>
+            <td>{{ processedMetrics.maxOutPercent3 }}%</td>
+            <td>{{ processedMetrics.maxOutPercent4 }}%</td>
+            <td>{{ processedMetrics.maxOutPercent5 }}%</td>
+            <td>{{ processedMetrics.maxOutPercent6 }}%</td>
+            <td>{{ processedMetrics.maxOutPercent7 }}%</td>
+            <td>{{ processedMetrics.maxOutPercent8 }}%</td>
+          </tr>
+          <tr>
+            <td>Force Off</td>
+            <td>{{ processedMetrics.forceOffPercent1 }}%</td>
+            <td>{{ processedMetrics.forceOffPercent2 }}%</td>
+            <td>{{ processedMetrics.forceOffPercent3 }}%</td>
+            <td>{{ processedMetrics.forceOffPercent4 }}%</td>
+            <td>{{ processedMetrics.forceOffPercent5 }}%</td>
+            <td>{{ processedMetrics.forceOffPercent6 }}%</td>
+            <td>{{ processedMetrics.forceOffPercent7 }}%</td>
+            <td>{{ processedMetrics.forceOffPercent8 }}%</td>
+          </tr>
+          <tr>
+            <td>Skipped</td>
+            <td>{{ processedMetrics.skippedPercent1 }}%</td>
+            <td>{{ processedMetrics.skippedPercent2 }}%</td>
+            <td>{{ processedMetrics.skippedPercent3 }}%</td>
+            <td>{{ processedMetrics.skippedPercent4 }}%</td>
+            <td>{{ processedMetrics.skippedPercent5 }}%</td>
+            <td>{{ processedMetrics.skippedPercent6 }}%</td>
+            <td>{{ processedMetrics.skippedPercent7 }}%</td>
+            <td>{{ processedMetrics.skippedPercent8 }}%</td>
+          </tr>
+          <tr>
+            <td>Total Count</td>
+            <td>{{ processedMetrics.totalPhaseCalls1 }}</td>
+            <td>{{ processedMetrics.totalPhaseCalls2 }}</td>
+            <td>{{ processedMetrics.totalPhaseCalls3 }}</td>
+            <td>{{ processedMetrics.totalPhaseCalls4 }}</td>
+            <td>{{ processedMetrics.totalPhaseCalls5 }}</td>
+            <td>{{ processedMetrics.totalPhaseCalls6 }}</td>
+            <td>{{ processedMetrics.totalPhaseCalls7 }}</td>
+            <td>{{ processedMetrics.totalPhaseCalls8 }}</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <div v-else class="empty-state">No termination data available.</div>
+  </v-card-text>
+</template>
+
+<script>
+export default {
+  props: {
+    tableData: {
+      type: Array,
+      required: true,
+      value: [],
+    },
+  },
+  computed: {
+    processedMetrics() {
+      if (!this.isDataLoaded()) {
+        return null;
+      }
+
+      const phaseData = this.tableData[this.tableData.length - 1];
+      if (!phaseData) {
+        return null;
+      }
+
+      return {
+        gapOutPercent1: phaseData.gapOutPercents[0],
+        gapOutPercent2: phaseData.gapOutPercents[1],
+        gapOutPercent3: phaseData.gapOutPercents[2],
+        gapOutPercent4: phaseData.gapOutPercents[3],
+        gapOutPercent5: phaseData.gapOutPercents[4],
+        gapOutPercent6: phaseData.gapOutPercents[5],
+        gapOutPercent7: phaseData.gapOutPercents[6],
+        gapOutPercent8: phaseData.gapOutPercents[7],
+        maxOutPercent1: phaseData.maxOutPercents[0],
+        maxOutPercent2: phaseData.maxOutPercents[1],
+        maxOutPercent3: phaseData.maxOutPercents[2],
+        maxOutPercent4: phaseData.maxOutPercents[3],
+        maxOutPercent5: phaseData.maxOutPercents[4],
+        maxOutPercent6: phaseData.maxOutPercents[5],
+        maxOutPercent7: phaseData.maxOutPercents[6],
+        maxOutPercent8: phaseData.maxOutPercents[7],
+        forceOffPercent1: phaseData.forceOffPercents[0],
+        forceOffPercent2: phaseData.forceOffPercents[1],
+        forceOffPercent3: phaseData.forceOffPercents[2],
+        forceOffPercent4: phaseData.forceOffPercents[3],
+        forceOffPercent5: phaseData.forceOffPercents[4],
+        forceOffPercent6: phaseData.forceOffPercents[5],
+        forceOffPercent7: phaseData.forceOffPercents[6],
+        forceOffPercent8: phaseData.forceOffPercents[7],
+        skippedPercent1: phaseData.skippedPercents[0],
+        skippedPercent2: phaseData.skippedPercents[1],
+        skippedPercent3: phaseData.skippedPercents[2],
+        skippedPercent4: phaseData.skippedPercents[3],
+        skippedPercent5: phaseData.skippedPercents[4],
+        skippedPercent6: phaseData.skippedPercents[5],
+        skippedPercent7: phaseData.skippedPercents[6],
+        skippedPercent8: phaseData.skippedPercents[7],
+        totalPhaseCalls1: phaseData.totalPhaseCalls[0],
+        totalPhaseCalls2: phaseData.totalPhaseCalls[1],
+        totalPhaseCalls3: phaseData.totalPhaseCalls[2],
+        totalPhaseCalls4: phaseData.totalPhaseCalls[3],
+        totalPhaseCalls5: phaseData.totalPhaseCalls[4],
+        totalPhaseCalls6: phaseData.totalPhaseCalls[5],
+        totalPhaseCalls7: phaseData.totalPhaseCalls[6],
+        totalPhaseCalls8: phaseData.totalPhaseCalls[7],
+      };
+    },
+  },
+  methods: {
+    isDataLoaded() {
+      return this.tableData.length > 0;
+    },
+  },
+};
+</script>
+
+<style scoped>
+.empty-state {
+  color: rgba(0, 0, 0, 0.6);
+  font-style: italic;
+}
+</style>

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -95,6 +95,13 @@
         </v-col>
         <v-col cols="12" md="6">
           <v-card class="tool-card" variant="outlined">
+            <v-card-title class="card-title">Phase Termination Reasons</v-card-title>
+            <TerminationReasonTable
+              class="card-body"
+              :tableData="splitHistoryRows"
+            ></TerminationReasonTable>
+          </v-card>
+          <v-card class="tool-card" variant="outlined">
             <v-card-title class="card-title">Pedestrian Investigator</v-card-title>
             <v-card-text class="card-body">
               <PedestrianInvestigator
@@ -189,6 +196,7 @@ import PlotDetectionTimeSeries from "../components/foundational/PlotDetectionTim
 import InputBox from "../components/foundational/InputBox.vue";
 import ProcessSplitHistory from "../components/ProcessSplitHistory.vue";
 import TableDisplaySplit from "../components/foundational/TableDisplaySplit.vue";
+import TerminationReasonTable from "../components/foundational/TerminationReasonTable.vue";
 import PedestrianInvestigator from "./PedestrianInvestigator.vue";
 import convertTime from "../mixins/convertTime";
 import enumerationObj from "../data/enumerations.json";
@@ -200,6 +208,7 @@ export default {
     PlotDetectionTimeSeries,
     ProcessSplitHistory,
     TableDisplaySplit,
+    TerminationReasonTable,
     PedestrianInvestigator,
   },
   mixins: [convertTime],


### PR DESCRIPTION
### Motivation
- Separate the phase termination summary from the detailed split list so the dashboard shows termination metrics in their own panel to the right (above the Walk Phase Summary) and keep the cycle/phase split rows scrollable on the left.
- Improve layout and usability when many cycles/splits are present so the split list doesn't grow the left panel indefinitely.

### Description
- Added a new component `TerminationReasonTable.vue` to render termination percentages and total counts for phases (src/components/foundational/TerminationReasonTable.vue). 
- Reflowed the Dashboard view to place the termination table in the right column above the embedded `PedestrianInvestigator` (src/views/Dashboard.vue).
- Simplified `TableDisplaySplit.vue` by removing the termination-summary table from it and making the split-history rows scrollable via a new `.split-history-scroll` wrapper and related CSS (src/components/foundational/TableDisplaySplit.vue).
- Updated imports and component registration in the Dashboard to include the new termination table component.

### Testing
- Started the dev server with `npm run dev` and confirmed Vite served the app successfully (local server ready). 
- Ran a Playwright script that navigated to `/dashboard`, populated sample CSV lines into the input, clicked the `Process` button, waited for processing, and captured a screenshot showing the new layout; the script completed and produced `artifacts/dashboard-termination-layout.png` successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6975a02dc530832babda077edd768a2c)