### PR TITLE
Compact dashboard layout: stack phase/split, termination reasons, pedestrian tools; make explainer filters sticky

### DIFF
--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -78,42 +78,38 @@
         </v-card-text>
       </v-card>
 
-      <v-row class="tool-row" dense>
-        <v-col cols="12" md="6">
-          <v-card class="tool-card" variant="outlined">
-            <v-card-title class="card-title">Phase &amp; Split Table</v-card-title>
-            <v-card-text class="card-body">
-              <ProcessSplitHistory
-                ref="splitHistory"
-                :inputData="inputData"
-                :hideInput="true"
-                @phaseDurations="updateSplitHistory"
-              ></ProcessSplitHistory>
-              <TableDisplaySplit :tableData="splitHistoryRows"></TableDisplaySplit>
-            </v-card-text>
-          </v-card>
-        </v-col>
-        <v-col cols="12" md="6">
-          <v-card class="tool-card" variant="outlined">
-            <v-card-title class="card-title">Phase Termination Reasons</v-card-title>
-            <TerminationReasonTable
-              class="card-body"
-              :tableData="splitHistoryRows"
-            ></TerminationReasonTable>
-          </v-card>
-          <v-card class="tool-card" variant="outlined">
-            <v-card-title class="card-title">Pedestrian Investigator</v-card-title>
-            <v-card-text class="card-body">
-              <PedestrianInvestigator
-                ref="pedestrianInvestigator"
-                :embedded="true"
-                :inputData="inputData"
-                :signalId="selectedSignal"
-              ></PedestrianInvestigator>
-            </v-card-text>
-          </v-card>
-        </v-col>
-      </v-row>
+      <div class="stacked-tools">
+        <v-card class="tool-card" variant="outlined">
+          <v-card-title class="card-title">Phase &amp; Split Table</v-card-title>
+          <v-card-text class="card-body">
+            <ProcessSplitHistory
+              ref="splitHistory"
+              :inputData="inputData"
+              :hideInput="true"
+              @phaseDurations="updateSplitHistory"
+            ></ProcessSplitHistory>
+            <TableDisplaySplit :tableData="splitHistoryRows"></TableDisplaySplit>
+          </v-card-text>
+        </v-card>
+        <v-card class="tool-card" variant="outlined">
+          <v-card-title class="card-title">Phase Termination Reasons</v-card-title>
+          <TerminationReasonTable
+            class="card-body"
+            :tableData="splitHistoryRows"
+          ></TerminationReasonTable>
+        </v-card>
+        <v-card class="tool-card" variant="outlined">
+          <v-card-title class="card-title">Pedestrian Investigator</v-card-title>
+          <v-card-text class="card-body">
+            <PedestrianInvestigator
+              ref="pedestrianInvestigator"
+              :embedded="true"
+              :inputData="inputData"
+              :signalId="selectedSignal"
+            ></PedestrianInvestigator>
+          </v-card-text>
+        </v-card>
+      </div>
 
       <v-card class="tool-card" variant="outlined">
         <v-card-title class="card-title">High Resolution Explainer Tool</v-card-title>
@@ -426,10 +422,11 @@ export default {
 <style scoped>
 .dashboard-view {
   padding: 8px;
+  font-size: 0.9rem;
 }
 
 .dashboard-title {
-  font-size: 1.4rem;
+  font-size: 1.2rem;
   margin-bottom: 12px;
 }
 
@@ -452,16 +449,16 @@ export default {
 .status-card,
 .plot-card,
 .tool-card {
-  margin-bottom: 12px;
+  margin-bottom: 10px;
 }
 
 .card-title {
-  font-size: 1rem;
-  padding: 12px 16px 6px;
+  font-size: 0.95rem;
+  padding: 10px 14px 4px;
 }
 
 .card-body {
-  padding: 12px 16px 16px;
+  padding: 10px 14px 14px;
 }
 
 .status-row {
@@ -495,8 +492,27 @@ export default {
   gap: 4px;
 }
 
-.tool-row {
-  margin-top: 8px;
+.stacked-tools {
+  max-width: 1200px;
+  margin: 8px auto 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.stacked-tools :deep(.summary-wrapper h2) {
+  font-size: 1rem;
+  margin-bottom: 6px;
+}
+
+.stacked-tools :deep(.summary-table),
+.stacked-tools :deep(.v-table) {
+  font-size: 0.85rem;
+}
+
+.stacked-tools :deep(.summary-filter-input) {
+  font-size: 0.75rem;
+  padding: 4px 6px;
 }
 
 .empty-state {
@@ -506,9 +522,23 @@ export default {
 }
 
 .explainer-table {
-  max-height: 320px;
+  max-height: 300px;
   overflow: auto;
-  font-size: 0.85rem;
+  font-size: 0.8rem;
+}
+
+.explainer-table thead tr:first-child th {
+  position: sticky;
+  top: 0;
+  background: #fff;
+  z-index: 2;
+}
+
+.explainer-table thead tr.filter-row th {
+  position: sticky;
+  top: 34px;
+  background: #fff;
+  z-index: 1;
 }
 
 .filter-row th {


### PR DESCRIPTION
### Motivation
- Reduce UI footprint so dashboard components fit on high-resolution displays and are easier to scan. 
- Ensure the High Resolution Explainer filter row is always visible while scrolling the table. 
- Present the Phase & Split table, Phase Termination Reasons, and Walk Phase Summary stacked in the middle of the page with the walk summary last so each can be fully viewed.

### Description
- Replaced the previous two-column `v-row` layout for the phase/split, termination reasons, and pedestrian investigator tools with a single centered `.stacked-tools` column that stacks the three cards vertically and places the `PedestrianInvestigator` last. 
- Tightened global dashboard typography and paddings by reducing `font-size`, `card-title` sizes, and card padding to create a more compact layout. 
- Reduced the explainer table height and set the header and the filter row to `position: sticky` so the column headers and filter inputs remain visible while scrolling. 
- Scoped CSS additions target `.stacked-tools` and `.explainer-table` to adjust fonts, spacing, and sticky positioning while keeping existing component structure intact.

### Testing
- Launched the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` to serve the app and verified it started successfully. 
- Ran an automated Playwright script that navigated to `/dashboard`, populated sample high-resolution data, clicked `Process`, waited for the dashboard UI to render, and captured a screenshot at `artifacts/dashboard-layout.png`, which completed successfully. 
- No unit tests were changed or required for these UI-only adjustments.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6975af7fb3d4832b865af2113ef1557b)