### PR TITLE
Add coord pattern change markers to detection timeseries plot

### DIFF
--- a/src/components/ProcessDetectionEvents.vue
+++ b/src/components/ProcessDetectionEvents.vue
@@ -29,6 +29,13 @@ export default {
         .filter((item) => item.eventDescriptor.toLowerCase().includes("detector"))
         .map((item) => parseInt(item.eventCode, 10));
     },
+    coordPatternEventCodes() {
+      return enumerationObj
+        .filter((item) =>
+          item.eventDescriptor.toLowerCase().includes("coord pattern change")
+        )
+        .map((item) => parseInt(item.eventCode, 10));
+    },
     phaseEventStates() {
       return enumerationObj.reduce((lookup, item) => {
         if (!item.parameterType || item.parameterType.toLowerCase() !== "phase") {
@@ -73,6 +80,7 @@ export default {
       const lines = this.inputData.split("\n");
       const events = [];
       const phaseEvents = [];
+      const coordPatternEvents = [];
 
       lines.forEach((line) => {
         const trimmedLine = line.trim();
@@ -110,6 +118,17 @@ export default {
           });
         }
 
+        if (this.coordPatternEventCodes.includes(eventCode)) {
+          coordPatternEvents.push({
+            timestampISO: timestampInfo.iso,
+            timestampMs: timestampInfo.MillisecFromEpoch,
+            humanReadable: timestampInfo.humanReadable,
+            eventCode,
+            eventDescriptor: this.detectionLookup[eventCode] ?? `Event ${eventCode}`,
+            parameterCode,
+          });
+        }
+
         const phaseState = this.phaseEventStates[eventCode];
         if (phaseState) {
           phaseEvents.push({
@@ -126,8 +145,10 @@ export default {
 
       events.sort((a, b) => a.timestampMs - b.timestampMs);
       phaseEvents.sort((a, b) => a.timestampMs - b.timestampMs);
+      coordPatternEvents.sort((a, b) => a.timestampMs - b.timestampMs);
       this.$emit("detectionEvents", events);
       this.$emit("phaseEvents", phaseEvents);
+      this.$emit("coordPatternEvents", coordPatternEvents);
     },
   },
 };

--- a/src/views/HighResDetectionPlotter.vue
+++ b/src/views/HighResDetectionPlotter.vue
@@ -46,6 +46,7 @@
       ref="processDetectionEvents"
       @detectionEvents="storeDetectionEvents"
       @phaseEvents="storePhaseEvents"
+      @coordPatternEvents="storeCoordPatternEvents"
     ></ProcessDetectionEvents>
     <div>
       <v-btn @click="processDetection" color="primary">
@@ -55,6 +56,7 @@
     <PlotDetectionTimeSeries
       :plotData="detectionEvents"
       :phaseData="phaseEvents"
+      :coordPatternData="coordPatternEvents"
     ></PlotDetectionTimeSeries>
   </div>
 </template>
@@ -74,6 +76,7 @@ export default {
       panel: [],
       detectionEvents: [],
       phaseEvents: [],
+      coordPatternEvents: [],
     };
   },
   methods: {
@@ -85,6 +88,9 @@ export default {
     },
     storePhaseEvents(events) {
       this.phaseEvents = events;
+    },
+    storeCoordPatternEvents(events) {
+      this.coordPatternEvents = events;
     },
   },
 };


### PR DESCRIPTION
### Motivation
- Surface coordination pattern change events on the detection timeseries so users can see when patterns change relative to detection and phase events.
- Use distinct, thin vertical indicators per pattern number so multiple pattern changes are visually distinguishable.

### Description
- Capture coordination pattern change event codes in `ProcessDetectionEvents.vue` via a new computed `coordPatternEventCodes`, collect `coordPatternEvents`, sort them, and emit them with the event stream as `coordPatternEvents`.
- Wire the emitted data through the view by adding a `@coordPatternEvents` handler and passing `:coordPatternData` to `PlotDetectionTimeSeries` in `HighResDetectionPlotter.vue`.
- Extend `PlotDetectionTimeSeries.vue` with a new `coordPatternData` prop and include those timestamps in `chartEndTimestamp` and `eventRange` calculations, compute unique pattern numbers, derive a per-pattern color map, and build a set of `line` datasets that render vertical lines (two points spanning the chart y-range) with unique HSL colors and `borderWidth` ~1.5 for thin but visible lines.
- Include tooltip formatting for coord pattern events so tooltips show the pattern number and timestamp.

### Testing
- Started the dev server with `npm run dev -- --host 0.0.0.0 --port 4173`, which launched Vite successfully. 
- Attempted automated visual validation with Playwright to capture a screenshot, but Chromium crashed (TargetClosedError / SIGSEGV) so the screenshot step failed. No other automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978291bd160832b9e811e8e751ddfc4)