### PR TITLE
Detect recurring pedestrian calls and add separate pedestrian table

### DIFF
--- a/src/components/ProcessStuckDetectors.vue
+++ b/src/components/ProcessStuckDetectors.vue
@@ -10,6 +10,7 @@
     </div>
 
     <div v-if="tableItems.length" class="table-wrapper">
+      <h3>Detectors Stuck On</h3>
       <v-data-table
         :headers="headers"
         :items="tableItems"
@@ -22,13 +23,31 @@
         </template>
       </v-data-table>
     </div>
-    <div v-else class="empty-state">
+    <div v-if="pedTableItems.length" class="table-wrapper">
+      <h3>Pedestrian Detectors Called Every Cycle</h3>
+      <v-data-table
+        :headers="headers"
+        :items="pedTableItems"
+        :sort-by="sortBy"
+        item-value="detectorId"
+        density="comfortable"
+      >
+        <template #item.percentOn="{ item }">
+          {{ item.percentOn.toFixed(1) }}%
+        </template>
+      </v-data-table>
+      <p class="ped-recall-note">Note: This could be on pedestrian recall.</p>
+    </div>
+    <div v-if="!tableItems.length && !pedTableItems.length" class="empty-state">
       <em v-if="hasProcessed">No stuck detectors found after processing data.</em>
       <em v-else>Paste data and click process to find stuck detectors.</em>
     </div>
     <div
       v-if="hasProcessed"
-      :class="['analysis-summary', { 'analysis-summary--clear': !tableItems.length }]"
+      :class="[
+        'analysis-summary',
+        { 'analysis-summary--clear': !tableItems.length && !pedTableItems.length },
+      ]"
     >
       <p>{{ analysisSummary }}</p>
     </div>
@@ -41,6 +60,10 @@ import InputBox from "./foundational/InputBox.vue";
 
 const ON_EVENT_CODES = new Set([82, 90]);
 const OFF_EVENT_CODES = new Set([81, 89]);
+const PED_ON_EVENT = 90;
+const PED_OFF_EVENT = 89;
+const PED_CYCLE_PERCENT_THRESHOLD = 80;
+const PED_CYCLE_MIN_ON_EVENTS = 2;
 
 export default {
   mixins: [convertTime],
@@ -60,6 +83,7 @@ export default {
       ],
       sortBy: [{ key: "percentOn", order: "desc" }],
       tableItems: [],
+      pedTableItems: [],
       hasProcessed: false,
       analysisSummary: "",
       dataDefaultText:
@@ -73,6 +97,7 @@ export default {
 
       if (events.length < 2) {
         this.tableItems = [];
+        this.pedTableItems = [];
         this.analysisSummary =
           "Methodology: parsed high-resolution events and searched for detectors that stayed ON without a matching OFF. There was not enough data to evaluate, so nothing stands out yet.";
         return;
@@ -83,6 +108,7 @@ export default {
       const totalDuration = lastMillis - firstMillis;
       if (totalDuration <= 0) {
         this.tableItems = [];
+        this.pedTableItems = [];
         this.analysisSummary =
           "Methodology: parsed high-resolution events and searched for detectors that stayed ON without a matching OFF. The time span was too short or invalid, so there is nothing to investigate.";
         return;
@@ -99,6 +125,11 @@ export default {
             lastOnStart: null,
             hasOnEvent: false,
             hasOffEvent: false,
+            onEvents: 0,
+            offEvents: 0,
+            lastOffTime: null,
+            offDuration: 0,
+            isPed: false,
           });
         }
         return detectorStats.get(detectorId);
@@ -114,19 +145,32 @@ export default {
         }
         const stats = ensureStats(detectorId);
         if (ON_EVENT_CODES.has(event.eventCode)) {
+          if (event.eventCode === PED_ON_EVENT) {
+            stats.isPed = true;
+          }
           stats.hasOnEvent = true;
+          stats.onEvents += 1;
           if (!stats.isOn) {
+            if (stats.lastOffTime !== null) {
+              stats.offDuration += event.millis - stats.lastOffTime;
+              stats.lastOffTime = null;
+            }
             stats.isOn = true;
             stats.lastOnStart = event.millis;
           }
         }
         if (OFF_EVENT_CODES.has(event.eventCode)) {
+          if (event.eventCode === PED_OFF_EVENT) {
+            stats.isPed = true;
+          }
           stats.hasOffEvent = true;
+          stats.offEvents += 1;
           if (stats.isOn && stats.lastOnStart !== null) {
             stats.onDuration += event.millis - stats.lastOnStart;
           }
           stats.isOn = false;
           stats.lastOnStart = null;
+          stats.lastOffTime = event.millis;
         }
       });
 
@@ -137,25 +181,57 @@ export default {
       });
 
       const items = [];
+      const pedCycleItems = [];
       detectorStats.forEach((stats) => {
-        if (!stats.hasOnEvent || stats.hasOffEvent) {
-          return;
-        }
         const percentOn = (stats.onDuration / totalDuration) * 100;
-        items.push({
-          detectorId: stats.detectorId,
-          percentOn,
-        });
+        if (stats.hasOnEvent && !stats.hasOffEvent) {
+          items.push({
+            detectorId: stats.detectorId,
+            percentOn,
+          });
+        }
+        if (
+          stats.isPed &&
+          stats.hasOnEvent &&
+          stats.hasOffEvent &&
+          stats.onEvents >= PED_CYCLE_MIN_ON_EVENTS &&
+          percentOn >= PED_CYCLE_PERCENT_THRESHOLD
+        ) {
+          pedCycleItems.push({
+            detectorId: stats.detectorId,
+            percentOn,
+          });
+        }
       });
 
       this.tableItems = items.sort((a, b) => b.percentOn - a.percentOn);
+      this.pedTableItems = pedCycleItems.sort((a, b) => b.percentOn - a.percentOn);
       const detectorCount = detectorStats.size;
       const flaggedCount = this.tableItems.length;
-      if (flaggedCount > 0) {
-        const topDetector = this.tableItems[0];
-        this.analysisSummary = `Methodology: parsed ${events.length} events and compared ON/OFF pairs for ${detectorCount} detector(s), flagging any detector that stayed ON without a matching OFF. Found ${flaggedCount} detector(s) to investigate, with detector ${topDetector.detectorId} at ${topDetector.percentOn.toFixed(
-          1,
-        )}% ON time as the highest priority.`;
+      const pedCycleCount = this.pedTableItems.length;
+      if (flaggedCount > 0 || pedCycleCount > 0) {
+        const summaryParts = [
+          `Methodology: parsed ${events.length} events and compared ON/OFF pairs for ${detectorCount} detector(s), flagging any detector that stayed ON without a matching OFF.`,
+          "Also highlighted pedestrian detectors that stayed active for most cycles despite OFF events.",
+        ];
+        if (flaggedCount > 0) {
+          const topDetector = this.tableItems[0];
+          summaryParts.push(
+            `Found ${flaggedCount} stuck detector(s) to investigate, with detector ${topDetector.detectorId} at ${topDetector.percentOn.toFixed(
+              1,
+            )}% ON time as the highest priority.`,
+          );
+        } else {
+          summaryParts.push("No detectors were stuck ON without a matching OFF.");
+        }
+        if (pedCycleCount > 0) {
+          summaryParts.push(
+            `Identified ${pedCycleCount} pedestrian detector(s) called every cycle for follow-up.`,
+          );
+        } else {
+          summaryParts.push("No pedestrian detectors showed repeat every-cycle calls.");
+        }
+        this.analysisSummary = summaryParts.join(" ");
       } else {
         this.analysisSummary = `Methodology: parsed ${events.length} events and compared ON/OFF pairs for ${detectorCount} detector(s), flagging any detector that stayed ON without a matching OFF. No stuck detectors were identified, so there is nothing specific to investigate right now.`;
       }
@@ -201,6 +277,16 @@ export default {
 
 .table-wrapper {
   margin-top: 12px;
+}
+
+.table-wrapper h3 {
+  margin-bottom: 8px;
+}
+
+.ped-recall-note {
+  margin: 8px 0 0;
+  font-style: italic;
+  color: rgba(var(--v-theme-on-surface), 0.7);
 }
 
 .empty-state {


### PR DESCRIPTION
### Motivation

- Improve stuck-detector analysis to better surface pedestrian detectors that are repeatedly called every cycle rather than strictly "stuck ON" by themselves. 
- Provide a dedicated UI table for these recurring pedestrian calls so they are more visible and can be triaged separately. 
- Add a short note to remind that repeated pedestrian calls may be due to pedestrian recall.

### Description

- Add new pedestrian classification constants `PED_ON_EVENT`, `PED_OFF_EVENT`, `PED_CYCLE_PERCENT_THRESHOLD`, and `PED_CYCLE_MIN_ON_EVENTS` to tune recurring-ped detection logic. 
- Extend the detector statistics (`onEvents`, `offEvents`, `lastOffTime`, `isPed`) to track per-detector on/off counts and durations for identifying recurring ped calls. 
- Classify detectors into two outputs: `tableItems` for detectors that appear stuck ON without OFF events, and `pedTableItems` for pedestrian detectors that are called every cycle (meeting the threshold/min-on criteria). 
- Update the template to render two separate tables with headings: "Detectors Stuck On" and "Pedestrian Detectors Called Every Cycle", and add a recall note (`Note: This could be on pedestrian recall.`). 
- Update the analysis summary to incorporate both stuck detectors and recurring pedestrian-call findings and tweak the clear-summary styling to consider both tables.

### Testing

- Started the dev server with `npm run dev` to validate the UI changes, but the app endpoint was not reachable at `http://127.0.0.1:4173` (connection refused) and `http://0.0.0.0:4173` returned an HTTP 403, so full browser verification could not be completed. 
- Attempted to capture a page screenshot via Playwright, but navigation failed with `ERR_EMPTY_RESPONSE` due to the server connectivity issue. 
- Performed local source inspection of `src/components/ProcessStuckDetectors.vue` to confirm template, script, and style updates were applied as intended.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697829622190832b8b4b1eebbe3be21a)