### PR TITLE
Add distinct colors for coordination pattern lines

### DIFF
--- a/src/components/foundational/PlotDetectionTimeSeries.vue
+++ b/src/components/foundational/PlotDetectionTimeSeries.vue
@@ -321,9 +321,28 @@ export default {
     },
     coordPatternColors() {
       const count = this.coordPatternNumbers.length;
+      const basePalette = [
+        "#e53935",
+        "#1e88e5",
+        "#43a047",
+        "#8e24aa",
+        "#f4511e",
+        "#3949ab",
+        "#00897b",
+        "#f9a825",
+        "#6d4c41",
+        "#5e35b1",
+      ];
+      const extraCount = Math.max(count - basePalette.length, 1);
       const colorMap = {};
       this.coordPatternNumbers.forEach((pattern, index) => {
-        const hue = Math.round((index / Math.max(count, 1)) * 320);
+        if (index < basePalette.length) {
+          colorMap[pattern] = basePalette[index];
+          return;
+        }
+        const hue = Math.round(
+          ((index - basePalette.length) / extraCount) * 360
+        );
         colorMap[pattern] = `hsl(${hue}, 70%, 45%)`;
       });
       return colorMap;


### PR DESCRIPTION
### Motivation
- Ensure coordination pattern change events plotted on the Timeseries Plot (Detection Channels) render with unique, easily distinguishable colors so pattern numbers are visually distinct.
- Provide a clear, deterministic palette and sensible fallback generation when the number of patterns exceeds the palette size.

### Description
- Update `src/components/foundational/PlotDetectionTimeSeries.vue` to add a `basePalette` of distinct hex colors and use those colors for the first patterns, with generated `hsl(...)` fallbacks for any additional patterns.
- Compute `extraCount` and spread fallback hues evenly across 360 degrees to avoid color collisions for large numbers of patterns.
- The coord-pattern datasets (`coordPatternLineDataset`) continue to map each pattern to its color via the new `coordPatternColors` lookup.

### Testing
- Launched the dev server with `npm run dev` (Vite) and confirmed the site became available (Vite ready output observed). The server start succeeded.
- Ran a Playwright smoke script that navigated to `/detection-plotter`, pasted sample CSV detection + coord pattern events, clicked `Process Detection Events`, and captured a screenshot to `artifacts/detection-plotter-coord-pattern-lines.png`; the script completed and produced the artifact.
- No unit tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697841941370832b84866e9c68aa7435)