### PR TITLE
Add missing canonical routes to public/sitemap.xml

### DIFF
--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -15,9 +15,17 @@
   <url><loc>https://trafficsignalkit.com/gpx-elevation</loc></url>
   <url><loc>https://trafficsignalkit.com/detectorRLR</loc></url>
   <url><loc>https://trafficsignalkit.com/preemption-plotter</loc></url>
+  <url><loc>https://trafficsignalkit.com/enumeration-matrix</loc></url>
   <url><loc>https://trafficsignalkit.com/detection-plotter</loc></url>
   <url><loc>https://trafficsignalkit.com/delay-estimator</loc></url>
+  <url><loc>https://trafficsignalkit.com/yellow-red-running</loc></url>
+  <url><loc>https://trafficsignalkit.com/stuck-detectors</loc></url>
+  <url><loc>https://trafficsignalkit.com/signal-offsets</loc></url>
+  <url><loc>https://trafficsignalkit.com/pedestrian-investigator</loc></url>
+  <url><loc>https://trafficsignalkit.com/dashboard</loc></url>
   <url><loc>https://trafficsignalkit.com/practice-exam</loc></url>
+  <url><loc>https://trafficsignalkit.com/video-frame-extractor</loc></url>
+  <url><loc>https://trafficsignalkit.com/phase-start-table</loc></url>
   <url><loc>https://trafficsignalkit.com/message-sign-designer</loc></url>
   <url><loc>https://trafficsignalkit.com/reference</loc></url>
 </urlset>


### PR DESCRIPTION
### Motivation
- Ensure all canonical, indexable routes declared in `src/router/index.js` are present in `public/sitemap.xml` so search engines can discover the app's tools and dashboards.
- Add missing tooling and dashboard pages such as `/dashboard`, `/enumeration-matrix`, `/yellow-red-running`, and related routes that were not previously indexed.

### Description
- Added `<url><loc>https://trafficsignalkit.com/...</loc></url>` entries to `public/sitemap.xml` for `enumeration-matrix`, `yellow-red-running`, `stuck-detectors`, `signal-offsets`, `pedestrian-investigator`, `dashboard`, `video-frame-extractor`, and `phase-start-table`.
- The change is limited to `public/sitemap.xml` and does not modify router definitions or view components.
- Committed the updated `public/sitemap.xml` file with a descriptive message.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69784d822584832bbdc4a0307993a5bb)