### PR TITLE
Revamp split calculator UI — Traffic Signal Split Calculator 2 with full-cycle & status logging

### DIFF
--- a/src/components/RingBarrier.vue
+++ b/src/components/RingBarrier.vue
@@ -1,52 +1,205 @@
 <template>
-  <div class="cycle-length">
-    <v-row justify="center">
-      <h3>Desired Cycle Length (seconds):</h3>
-    </v-row>
-    <v-row justify="center">
-      <v-col cols="3">
-        <v-responsive max-width="200">
-          <v-text-field
-            class="mt-2"
-            auto-grow
-            variant="outlined"
-            counter="number"
-            :rules="[(v) => /^-?\d+$/.test(v)]"
-            row-height="15"
-            v-model="desiredCL"
-            placeholder="desired cycle length (sec)"
-          >
-          </v-text-field>
-        </v-responsive>
-      </v-col>
-      <v-col cols="4">
-        <br />
-        <v-slider
-          v-model="desiredCL"
-          :min="0"
-          :max="500"
-          :step="1"
-          thumb-label
-        ></v-slider>
-      </v-col>
-    </v-row>
+  <v-container class="pa-4 split-calculator">
+    <v-card class="mb-6" elevation="3">
+      <v-card-title class="d-flex flex-column flex-md-row align-start">
+        <div class="flex-grow-1">
+          <h2 class="text-h5 mb-1">Cycle Controls</h2>
+          <div class="text-subtitle-2">
+            Set the desired cycle length and review ring totals at a glance.
+          </div>
+        </div>
+        <v-chip
+          class="mt-3 mt-md-0"
+          color="primary"
+          variant="tonal"
+          size="large"
+        >
+          Full Cycle: {{ fullCycleLength }}s
+        </v-chip>
+      </v-card-title>
+      <v-card-text>
+        <v-row align="center" justify="center" class="mb-4">
+          <v-col cols="12" md="3">
+            <v-text-field
+              class="mt-2"
+              auto-grow
+              variant="outlined"
+              counter="number"
+              :rules="[(v) => /^-?\\d+$/.test(v)]"
+              row-height="15"
+              v-model="desiredCL"
+              label="Desired cycle length (sec)"
+            >
+            </v-text-field>
+          </v-col>
+          <v-col cols="12" md="5">
+            <v-slider
+              v-model="desiredCL"
+              :min="0"
+              :max="500"
+              :step="1"
+              thumb-label
+            ></v-slider>
+          </v-col>
+          <v-col cols="12" md="4" class="text-center">
+            <v-btn
+              color="primary"
+              variant="outlined"
+              class="ma-1"
+              @click="distributeEvenly"
+            >
+              Evenly Distribute
+            </v-btn>
+            <v-btn
+              color="success"
+              variant="outlined"
+              class="ma-1"
+              @click="distribute2080on26"
+            >
+              20%/80% Distribution
+            </v-btn>
+            <v-btn
+              color="info"
+              variant="outlined"
+              class="ma-1"
+              @click="syncDesiredToFullCycle"
+            >
+              Use Full Cycle
+            </v-btn>
+          </v-col>
+        </v-row>
+        <v-row class="text-center">
+          <v-col cols="12" md="3">
+            <v-sheet class="pa-3 summary-tile">
+              <div class="text-caption">Ring 1 Total</div>
+              <div class="text-h6">{{ ring1CL }}s</div>
+            </v-sheet>
+          </v-col>
+          <v-col cols="12" md="3">
+            <v-sheet class="pa-3 summary-tile">
+              <div class="text-caption">Ring 2 Total</div>
+              <div class="text-h6">{{ ring2CL }}s</div>
+            </v-sheet>
+          </v-col>
+          <v-col cols="12" md="3">
+            <v-sheet class="pa-3 summary-tile">
+              <div class="text-caption">Full Cycle Difference</div>
+              <div class="text-h6">
+                {{ fullCycleDifference }}s
+              </div>
+            </v-sheet>
+          </v-col>
+          <v-col cols="12" md="3">
+            <v-sheet class="pa-3 summary-tile">
+              <div class="text-caption">Desired Cycle</div>
+              <div class="text-h6">{{ desiredCL }}s</div>
+            </v-sheet>
+          </v-col>
+        </v-row>
+      </v-card-text>
+    </v-card>
 
-    <v-row justify="center">
-      <v-btn color="primary" variant="outlined" @click="distributeEvenly">
-        Evenly Distribute
-      </v-btn>
+    <v-card class="mb-6" elevation="2">
+      <v-card-title>
+        <div>
+          <h3 class="text-h6 mb-1">Current Status</h3>
+          <div class="text-subtitle-2">
+            Paste split values to load the current state, then set the baseline
+            to start logging changes.
+          </div>
+        </div>
+      </v-card-title>
+      <v-card-text>
+        <v-row>
+          <v-col cols="12" md="7">
+            <v-textarea
+              v-model="currentStatusInput"
+              label="Paste current status values (ex: 10 15 10 15 10 15 10 15)"
+              rows="2"
+              auto-grow
+              variant="outlined"
+            ></v-textarea>
+          </v-col>
+          <v-col cols="12" md="5" class="d-flex flex-column justify-center">
+            <v-btn
+              color="primary"
+              variant="outlined"
+              class="mb-2"
+              @click="applyCurrentStatus"
+            >
+              Apply Pasted Status
+            </v-btn>
+            <v-btn
+              color="success"
+              variant="outlined"
+              @click="setCurrentStatus"
+            >
+              Set Current Status &amp; Start Log
+            </v-btn>
+          </v-col>
+        </v-row>
+        <v-alert
+          v-if="statusError"
+          type="error"
+          variant="tonal"
+          class="mb-3"
+        >
+          {{ statusError }}
+        </v-alert>
+        <v-alert v-if="statusMessage" type="success" variant="tonal">
+          {{ statusMessage }}
+        </v-alert>
+        <div class="mt-4 text-subtitle-2">
+          Current Snapshot:
+          <span class="font-weight-medium">{{ currentSnapshot }}</span>
+        </div>
+        <div class="text-subtitle-2">
+          Baseline Snapshot:
+          <span class="font-weight-medium">{{ baselineSnapshot }}</span>
+        </div>
+      </v-card-text>
+    </v-card>
 
-      &nbsp;&nbsp;&nbsp;
-      <v-btn color="success" variant="outlined" @click="distribute2080on26">
-        20%/80% Distribution
-      </v-btn>
-    </v-row>
-  </div>
-
-  <br />
-  <hr />
-  <br />
-  <br />
+    <v-card class="mb-6" elevation="2">
+      <v-card-title>
+        <h3 class="text-h6">Change Log</h3>
+      </v-card-title>
+      <v-card-text>
+        <v-table density="compact">
+          <thead>
+            <tr>
+              <th class="text-left">Step</th>
+              <th class="text-left">Time</th>
+              <th class="text-left">Change</th>
+              <th class="text-left">From</th>
+              <th class="text-left">To</th>
+              <th class="text-left">Ring 1</th>
+              <th class="text-left">Ring 2</th>
+              <th class="text-left">Full Cycle</th>
+              <th class="text-left">Snapshot</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-if="statusLog.length === 0">
+              <td colspan="9" class="text-center text-medium-emphasis">
+                Set the current status to begin logging updates.
+              </td>
+            </tr>
+            <tr v-for="entry in statusLog" :key="entry.id">
+              <td>{{ entry.id }}</td>
+              <td>{{ entry.time }}</td>
+              <td>{{ entry.label }}</td>
+              <td>{{ entry.from }}</td>
+              <td>{{ entry.to }}</td>
+              <td>{{ entry.ring1CL }}</td>
+              <td>{{ entry.ring2CL }}</td>
+              <td>{{ entry.fullCycleLength }}</td>
+              <td>{{ entry.snapshot }}</td>
+            </tr>
+          </tbody>
+        </v-table>
+      </v-card-text>
+    </v-card>
 
   <!-- First Ring-->
   <v-table density="compact">
@@ -207,7 +360,7 @@
     </tbody>
   </v-table>
 
-  <br />
+  </v-container>
 </template>
 
 <script>
@@ -229,6 +382,12 @@ export default {
       maxValue: 0,
       cl20: 0,
       cl80: 0,
+      currentStatusInput: "",
+      currentStatusSet: false,
+      baselineStatus: null,
+      statusLog: [],
+      statusMessage: "",
+      statusError: "",
     };
   },
   computed: {
@@ -269,49 +428,160 @@ export default {
         return this.minValue;
       }
     },
+    fullCycleLength() {
+      return Math.max(this.ring1CL, this.ring2CL);
+    },
+    fullCycleDifference() {
+      return this.fullCycleLength - this.desiredCL;
+    },
+    currentSnapshot() {
+      return this.snapshotString();
+    },
+    baselineSnapshot() {
+      if (!this.baselineStatus) {
+        return "Not set";
+      }
+      return this.formatSnapshot(this.baselineStatus);
+    },
   },
   methods: {
     r1p1(phase) {
-      this.r1ph1 = phase;
-      console.log("changed CL: " + this.cyclelength);
+      this.setPhaseValue("r1ph1", phase, "Ring 1 - Phase 1");
     },
     r1p2(phase) {
-      this.r1ph2 = phase;
-      console.log("changed CL: " + this.cyclelength);
+      this.setPhaseValue("r1ph2", phase, "Ring 1 - Phase 2");
     },
     r1p3(phase) {
-      this.r1ph3 = phase;
-      console.log("changed CL: " + this.cyclelength);
+      this.setPhaseValue("r1ph3", phase, "Ring 1 - Phase 3");
     },
     r1p4(phase) {
-      this.r1ph4 = phase;
-      console.log("changed CL: " + this.cyclelength);
+      this.setPhaseValue("r1ph4", phase, "Ring 1 - Phase 4");
     },
     r2p1(phase) {
-      this.r2ph1 = phase;
-      console.log("changed CL: " + this.cyclelength);
+      this.setPhaseValue("r2ph1", phase, "Ring 2 - Phase 5");
     },
     r2p2(phase) {
-      this.r2ph2 = phase;
-      console.log("changed CL: " + this.cyclelength);
+      this.setPhaseValue("r2ph2", phase, "Ring 2 - Phase 6");
     },
     r2p3(phase) {
-      this.r2ph3 = phase;
-      console.log("changed CL: " + this.cyclelength);
+      this.setPhaseValue("r2ph3", phase, "Ring 2 - Phase 7");
     },
     r2p4(phase) {
-      this.r2ph4 = phase;
-      console.log("changed CL: " + this.cyclelength);
+      this.setPhaseValue("r2ph4", phase, "Ring 2 - Phase 8");
     },
     distributeEvenly() {
-      this.r1ph1 = this.r1ph2 = this.r1ph3 = this.r1ph4 = this.desiredCL / 4;
-      this.r2ph1 = this.r2ph2 = this.r2ph3 = this.r2ph4 = this.desiredCL / 4;
+      const value = this.desiredCL / 4;
+      this.setPhaseValue("r1ph1", value, "Ring 1 - Phase 1");
+      this.setPhaseValue("r1ph2", value, "Ring 1 - Phase 2");
+      this.setPhaseValue("r1ph3", value, "Ring 1 - Phase 3");
+      this.setPhaseValue("r1ph4", value, "Ring 1 - Phase 4");
+      this.setPhaseValue("r2ph1", value, "Ring 2 - Phase 5");
+      this.setPhaseValue("r2ph2", value, "Ring 2 - Phase 6");
+      this.setPhaseValue("r2ph3", value, "Ring 2 - Phase 7");
+      this.setPhaseValue("r2ph4", value, "Ring 2 - Phase 8");
     },
     distribute2080on26() {
-      var cl20 = this.desiredCL * 0.1;
-      var cl80 = this.desiredCL * 0.4;
-      this.r1ph1 = this.r1ph3 = this.r2ph1 = this.r2ph3 = cl20;
-      this.r1ph2 = this.r1ph4 = this.r2ph2 = this.r2ph4 = cl80;
+      const cl20 = this.desiredCL * 0.1;
+      const cl80 = this.desiredCL * 0.4;
+      this.setPhaseValue("r1ph1", cl20, "Ring 1 - Phase 1");
+      this.setPhaseValue("r1ph3", cl20, "Ring 1 - Phase 3");
+      this.setPhaseValue("r2ph1", cl20, "Ring 2 - Phase 5");
+      this.setPhaseValue("r2ph3", cl20, "Ring 2 - Phase 7");
+      this.setPhaseValue("r1ph2", cl80, "Ring 1 - Phase 2");
+      this.setPhaseValue("r1ph4", cl80, "Ring 1 - Phase 4");
+      this.setPhaseValue("r2ph2", cl80, "Ring 2 - Phase 6");
+      this.setPhaseValue("r2ph4", cl80, "Ring 2 - Phase 8");
+    },
+    syncDesiredToFullCycle() {
+      this.desiredCL = this.fullCycleLength;
+    },
+    setPhaseValue(key, value, label) {
+      const previous = this[key];
+      if (previous === value) {
+        return;
+      }
+      this[key] = value;
+      this.recordStatusChange(label, previous, value);
+    },
+    applyCurrentStatus() {
+      this.statusError = "";
+      this.statusMessage = "";
+      const values = this.parseSplitValues(this.currentStatusInput);
+      if (values.length < 8) {
+        this.statusError =
+          "Please paste 8 numeric values to populate both rings.";
+        return;
+      }
+      const [r1ph1, r1ph2, r1ph3, r1ph4, r2ph1, r2ph2, r2ph3, r2ph4] =
+        values.slice(0, 8);
+      this.r1ph1 = r1ph1;
+      this.r1ph2 = r1ph2;
+      this.r1ph3 = r1ph3;
+      this.r1ph4 = r1ph4;
+      this.r2ph1 = r2ph1;
+      this.r2ph2 = r2ph2;
+      this.r2ph3 = r2ph3;
+      this.r2ph4 = r2ph4;
+      this.currentStatusSet = false;
+      this.baselineStatus = null;
+      this.statusLog = [];
+      this.statusMessage = "Current status values applied.";
+    },
+    setCurrentStatus() {
+      this.currentStatusSet = true;
+      this.baselineStatus = this.captureStatus();
+      this.statusLog = [];
+      this.statusMessage = "Current status set. Logging new changes.";
+      this.statusError = "";
+    },
+    recordStatusChange(label, from, to) {
+      if (!this.currentStatusSet) {
+        return;
+      }
+      this.statusLog.push({
+        id: this.statusLog.length + 1,
+        time: new Date().toLocaleTimeString(),
+        label,
+        from,
+        to,
+        ring1CL: this.ring1CL,
+        ring2CL: this.ring2CL,
+        fullCycleLength: this.fullCycleLength,
+        snapshot: this.snapshotString(),
+      });
+    },
+    parseSplitValues(input) {
+      return input
+        .split(/[\s,]+/)
+        .map((value) => Number(value))
+        .filter((value) => !Number.isNaN(value));
+    },
+    captureStatus() {
+      return {
+        r1ph1: this.r1ph1,
+        r1ph2: this.r1ph2,
+        r1ph3: this.r1ph3,
+        r1ph4: this.r1ph4,
+        r2ph1: this.r2ph1,
+        r2ph2: this.r2ph2,
+        r2ph3: this.r2ph3,
+        r2ph4: this.r2ph4,
+      };
+    },
+    formatSnapshot(status) {
+      return [
+        status.r1ph1,
+        status.r1ph2,
+        status.r1ph3,
+        status.r1ph4,
+        status.r2ph1,
+        status.r2ph2,
+        status.r2ph3,
+        status.r2ph4,
+      ].join(" / ");
+    },
+    snapshotString() {
+      return this.formatSnapshot(this.captureStatus());
     },
   },
 };
@@ -364,5 +634,9 @@ table {
 }
 .table-grey-background {
   background-color: #d0d0d0;
+}
+.split-calculator .summary-tile {
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
 }
 </style>

--- a/src/components/SplitCard.vue
+++ b/src/components/SplitCard.vue
@@ -1,7 +1,7 @@
 <template>
   <v-container class="grey lighten-5">
     <v-btn variant="tonal" color="success" @click="addCard">
-      New Split Calculator
+      New Split Calculator 2
     </v-btn>
 
     <v-row class="mb-6" justify="center" no-gutters>

--- a/src/seo/routes.js
+++ b/src/seo/routes.js
@@ -24,7 +24,7 @@ export const routeMeta = {
     path: "/terms-of-service",
   },
   SplitCalculator: {
-    title: "Traffic Signal Split Calculator | Coordination & Timing Checks",
+    title: "Traffic Signal Split Calculator 2 | Coordination & Timing Checks",
     description:
       "Verify split allocations and cycle lengths during coordination and timing plan adjustments.",
     path: "/split-calculator",

--- a/src/views/SplitCalculator.vue
+++ b/src/views/SplitCalculator.vue
@@ -2,14 +2,14 @@
   <div>
     &nbsp;
 
-    <h1 class="h1-center-text">Traffic Signal Split Calculator</h1>
+    <h1 class="h1-center-text">Traffic Signal Split Calculator 2</h1>
 
     <div class="left-justify-text">
       <v-expansion-panels v-model="panel" multiple>
         <v-expansion-panel title="About: Split Calculator" value="about">
           <v-expansion-panel-text>
-            This is a simple signal timing calculator for setting the "split"
-            time of traffic lights. It helps decide how long each phase can be
+            This is a signal timing calculator for setting the "split" time of
+            traffic lights. It helps decide how long each phase can be
             allocated. By balancing the green light time well, it helps to
             lessen traffic jams, make traffic flow smoother, and increase safety
             on the roads.


### PR DESCRIPTION
### Motivation
- Rename and modernize the split calculator to “Traffic Signal Split Calculator 2” and make the interface cleaner and more informative.
- Provide a visible full-cycle calculation so users can see the effective cycle length when rings differ and align desired cycle values quickly.
- Allow pasting a current-split snapshot and track subsequent changes with a change log so transitions from a baseline can be audited.

### Description
- Updated UI text and metadata to the new name in `src/views/SplitCalculator.vue`, `src/components/SplitCard.vue`, and `src/seo/routes.js`.
- Reworked `src/components/RingBarrier.vue` with a refreshed layout that adds cycle controls, a `Full Cycle` summary chip, `Use Full Cycle` sync button, and summary tiles for Ring 1/2 totals and differences.
- Added current-status workflow and logging: `currentStatusInput`, `applyCurrentStatus`, `setCurrentStatus`, `recordStatusChange`, `parseSplitValues`, `captureStatus`, and `formatSnapshot` to parse pasted values, set a baseline, and append change entries to `statusLog` (rendered in a table).
- Centralized phase updates through `setPhaseValue` and rewired `r1p1..r2p4`, `distributeEvenly`, and `distribute2080on26` to use it so changes are logged with ring totals and a snapshot string; minor styling added for summary tiles.

### Testing
- Attempted to run the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` to validate the UI, but the server endpoint was not reachable (connection refused).
- Attempted an automated Playwright screenshot against `http://127.0.0.1:4173/split-calculator`, which failed with `net::ERR_EMPTY_RESPONSE` and could not capture the UI.
- No other automated tests (unit or integration) were present or executed, so UI functionality verification remains pending due to the dev-server access failure.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69784f893ec4832ba37bed537d14eea7)