### PR TITLE
Make blog article card clickable

### DIFF
--- a/src/views/Blog.vue
+++ b/src/views/Blog.vue
@@ -14,7 +14,7 @@
         </p>
       </v-card-text>
     </v-card>
-    <v-card class="blog-card" variant="outlined">
+    <v-card class="blog-card blog-card--link" variant="outlined" to="/blog/offsets-are-the-point" link>
       <v-card-title>Offsets Are the Point</v-card-title>
       <v-card-subtitle>
         Why Cycle Length, Splits, and TOD Schedules Exist Only to Serve the Green Wave
@@ -49,5 +49,8 @@ export default {
 .blog-card {
   margin-top: 24px;
   border-radius: 16px;
+}
+.blog-card--link {
+  cursor: pointer;
 }
 </style>


### PR DESCRIPTION
### Motivation
- Make the blog article preview act as a direct link to its article so the entire card is clickable and discoverably interactive.

### Description
- Update `src/views/Blog.vue` to add `to="/blog/offsets-are-the-point"` and `link` to the article `v-card` and add a `.blog-card--link { cursor: pointer; }` style to indicate clickability.

### Testing
- Ran `npm run dev` which started Vite and served the app at `http://localhost:4173/`, but the attempted Playwright screenshot run failed due to headless browser errors so automated visual verification did not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69785954fe90832ba3fcc6cc2230ff93)