### PR TITLE
Style blog article as newspaper

### DIFF
--- a/src/views/OffsetsAreThePoint.vue
+++ b/src/views/OffsetsAreThePoint.vue
@@ -1,65 +1,72 @@
 <template>
   <v-container class="blog-article">
-    <h1 class="article-title">Offsets Are the Point</h1>
-    <p class="article-subtitle">
-      Why Cycle Length, Splits, and TOD Schedules Exist Only to Serve the Green Wave
-    </p>
+    <header class="article-header">
+      <p class="article-kicker">Traffic Signal Kit Journal</p>
+      <h1 class="article-title">Offsets Are the Point</h1>
+      <p class="article-subtitle">
+        Why Cycle Length, Splits, and TOD Schedules Exist Only to Serve the Green Wave
+      </p>
+      <p class="article-meta">By Traffic Signal Kit • Updated for corridor timing teams</p>
+    </header>
 
-    <p>
-      For decades, signal coordination has been taught as a balancing act between
-      cycle length, splits, and offsets. We build timing plans, define time-of-day
-      schedules, tweak phase splits, and re-optimize cycles. But let’s say the
-      quiet part out loud:
-    </p>
-    <p class="article-callout">
-      Offsets are the goal. Everything else exists only to support them.
-    </p>
-    <p>
-      Cycle lengths, phase splits, and even time-of-day plans are not the end—they
-      are scaffolding. The true performance of a coordinated system is measured by
-      one thing: did the platoon arrive on green? If the answer is yes, drivers
-      feel like the system is working. If not, no amount of perfect splits will
-      save it.
-    </p>
+    <section class="article-body">
+      <p class="article-lead">
+        For decades, signal coordination has been taught as a balancing act between
+        cycle length, splits, and offsets. We build timing plans, define time-of-day
+        schedules, tweak phase splits, and re-optimize cycles. But let’s say the
+        quiet part out loud:
+      </p>
+      <p class="article-callout">
+        Offsets are the goal. Everything else exists only to support them.
+      </p>
+      <p>
+        Cycle lengths, phase splits, and even time-of-day plans are not the end—they
+        are scaffolding. The true performance of a coordinated system is measured by
+        one thing: did the platoon arrive on green? If the answer is yes, drivers
+        feel like the system is working. If not, no amount of perfect splits will
+        save it.
+      </p>
 
-    <h2>The Green Wave Is the Product</h2>
-    <p>
-      When a driver moves down a corridor and hits three greens in a row, they
-      don’t think, “Ah yes, excellent phase allocation and cycle selection.” They
-      think, “This city knows what it’s doing.” That experience—the green wave—is
-      created almost entirely by offset alignment between signals. Offsets define
-      when the green window exists in space and time relative to upstream
-      intersections. Everything else simply defines how long that window is and
-      how often it repeats.
-    </p>
+      <h2>The Green Wave Is the Product</h2>
+      <p>
+        When a driver moves down a corridor and hits three greens in a row, they
+        don’t think, “Ah yes, excellent phase allocation and cycle selection.” They
+        think, “This city knows what it’s doing.” That experience—the green wave—is
+        created almost entirely by offset alignment between signals. Offsets define
+        when the green window exists in space and time relative to upstream
+        intersections. Everything else simply defines how long that window is and
+        how often it repeats.
+      </p>
 
-    <h2>The Traditional Stack (and Its Hidden Assumption)</h2>
-    <p>Traditional coordination usually follows this order:</p>
-    <ol>
-      <li>Pick a cycle length (90s, 120s, etc.)</li>
-      <li>Allocate splits for each phase</li>
-      <li>Define offsets between signals</li>
-      <li>Create TOD plans to handle demand changes</li>
-    </ol>
-    <p>
-      This stack hides a major assumption: that we must lock into a cycle first
-      and then fit offsets inside of it. But what if that assumption is
-      backwards? What if we started with the offsets?
-    </p>
+      <h2>The Traditional Stack (and Its Hidden Assumption)</h2>
+      <p>Traditional coordination usually follows this order:</p>
+      <ol>
+        <li>Pick a cycle length (90s, 120s, etc.)</li>
+        <li>Allocate splits for each phase</li>
+        <li>Define offsets between signals</li>
+        <li>Create TOD plans to handle demand changes</li>
+      </ol>
+      <p>
+        This stack hides a major assumption: that we must lock into a cycle first
+        and then fit offsets inside of it. But what if that assumption is
+        backwards? What if we started with the offsets?
+      </p>
 
-    <h2>Reframing the Problem: Offsets First</h2>
-    <p>
-      Instead of asking, “What cycle should this corridor run?” what if we asked:
-      “At what time should each signal turn green so the largest volume of
-      vehicles can pass through without stopping?”
-    </p>
-    <p>
-      That question is independent of cycle length, phase structure, and
-      time-of-day bins. It is purely a spatiotemporal alignment problem. Once we
-      know the optimal green arrival times, then we can wrap a cycle around them,
-      assign splits to protect them, and adjust side-street service as needed.
-      This flips the entire coordination paradigm.
-    </p>
+      <h2>Reframing the Problem: Offsets First</h2>
+      <p>
+        Instead of asking, “What cycle should this corridor run?” what if we asked:
+        “At what time should each signal turn green so the largest volume of
+        vehicles can pass through without stopping?”
+      </p>
+      <p>
+        That question is independent of cycle length, phase structure, and
+        time-of-day bins. It is purely a spatiotemporal alignment problem. Once we
+        know the optimal green arrival times, then we can wrap a cycle around them,
+        assign splits to protect them, and adjust side-street service as needed.
+        This flips the entire coordination paradigm.
+      </p>
+    </section>
+
     <v-btn class="back-link" color="primary" variant="text" to="/blog">
       Back to blog
     </v-btn>
@@ -76,23 +83,98 @@ export default {
 .blog-article {
   max-width: 960px;
   margin: 0 auto;
+  padding: 32px 20px 48px;
+  font-family: "Georgia", "Times New Roman", serif;
+  color: #111;
+}
+
+.article-header {
+  border-top: 4px solid #111;
+  border-bottom: 2px solid #111;
+  padding: 16px 0 20px;
+  margin-bottom: 28px;
+  text-align: center;
+}
+
+.article-kicker {
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  font-size: 0.75rem;
+  margin-bottom: 12px;
 }
 
 .article-title {
   margin-bottom: 8px;
+  font-size: clamp(2.2rem, 4vw, 3.3rem);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
 }
 
 .article-subtitle {
-  margin-bottom: 24px;
+  margin-bottom: 12px;
+  font-style: italic;
   color: rgba(0, 0, 0, 0.7);
+}
+
+.article-meta {
+  font-size: 0.9rem;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: rgba(0, 0, 0, 0.6);
 }
 
 .article-callout {
   font-weight: 600;
   font-size: 1.1rem;
+  font-style: italic;
+  border-left: 4px solid #111;
+  padding-left: 16px;
+  margin: 20px 0;
+}
+
+.article-body {
+  column-count: 2;
+  column-gap: 32px;
+  column-rule: 1px solid rgba(0, 0, 0, 0.2);
+  font-size: 1.02rem;
+  line-height: 1.7;
+}
+
+.article-body h2 {
+  break-inside: avoid;
+  page-break-inside: avoid;
+  margin-top: 24px;
+  font-size: 1.3rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.article-body p,
+.article-body ol {
+  break-inside: avoid;
+  page-break-inside: avoid;
+  margin-bottom: 16px;
+}
+
+.article-body ol {
+  padding-left: 20px;
+}
+
+.article-lead::first-letter {
+  float: left;
+  font-size: 3rem;
+  line-height: 0.9;
+  padding-right: 10px;
+  font-weight: 700;
 }
 
 .back-link {
   margin-top: 24px;
+}
+
+@media (max-width: 900px) {
+  .article-body {
+    column-count: 1;
+  }
 }
 </style>


### PR DESCRIPTION
### Motivation
- Improve the visual presentation of the "Offsets Are the Point" blog article to resemble a print/newspaper layout for stronger editorial feel and readability.
- Make the article more magazine-like for corridor timing teams by surfacing article metadata and typographic treatments that emphasize hierarchy.

### Description
- Restructure the article template by adding a newspaper-style header containing a kicker, title, subtitle, and metadata, and wrap article content in a dedicated `<section class="article-body">`.
- Replace single-column body with a multi-column layout and add a serif font stack for a print look, plus a drop-cap styling for the article lead first letter.
- Add visual callout styling with a left rule and italics, column rule and gap, typographic sizing and uppercase title treatments, and a responsive media query to fall back to a single column on narrow screens.
- Minor spacing, padding, and layout adjustments to center and frame the article for a newspaper appearance.

### Testing
- Launched the dev server with `npm run dev` and confirmed the application responds via `curl --noproxy '*' -I http://127.0.0.1:4173/` which returned `200 OK`.
- Executed a Playwright script to navigate to `http://127.0.0.1:4173/blog/offsets-are-the-point` and successfully captured a screenshot saved to `artifacts/offsets-article-newspaper.png`, validating the visual changes.
- Addressed an initial connection attempt and re-ran the browser script with proxy settings adjusted, after which the automated screenshot run succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697969f3fc44832ba846372ffa349405)