### PR TITLE
Add dark mode palette for blog article

### DIFF
--- a/src/views/OffsetsAreThePoint.vue
+++ b/src/views/OffsetsAreThePoint.vue
@@ -172,6 +172,34 @@ export default {
   margin-top: 24px;
 }
 
+@media (prefers-color-scheme: dark) {
+  .blog-article {
+    color: #f5f5f5;
+    background: #0f0f0f;
+  }
+
+  .article-header {
+    border-top-color: #f5f5f5;
+    border-bottom-color: #f5f5f5;
+  }
+
+  .article-subtitle {
+    color: rgba(255, 255, 255, 0.7);
+  }
+
+  .article-meta {
+    color: rgba(255, 255, 255, 0.6);
+  }
+
+  .article-callout {
+    border-left-color: #f5f5f5;
+  }
+
+  .article-body {
+    column-rule-color: rgba(255, 255, 255, 0.2);
+  }
+}
+
 @media (max-width: 900px) {
   .article-body {
     column-count: 1;


### PR DESCRIPTION
### Motivation
- Improve readability and visual consistency when visitors view the article in dark mode by inverting the article color palette and adjusting borders and rules for contrast.

### Description
- Added an `@media (prefers-color-scheme: dark)` block to `src/views/OffsetsAreThePoint.vue` that flips text and background colors and updates header borders, subtitle/meta text, callout border, and column-rule color.
- Targets include `.blog-article`, `.article-header`, `.article-subtitle`, `.article-meta`, `.article-callout`, and `.article-body` to ensure the article layout remains legible in dark mode.

### Testing
- Started the dev server with `npm run dev` and confirmed the site served at the local Vite URL (server started successfully).
- Ran a Playwright script that emulated dark mode and captured a screenshot of `/blog/offsets-are-the-point` using Firefox; the screenshot (`artifacts/offsets-dark-mode.png`) was produced successfully.
- A Chromium-based Playwright run failed due to a browser launch error, but the Firefox run validated the dark-mode appearance.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69797ab8ea40832b868394b4c18ef6ef)