### PR TITLE
Add Start Up Loss Average tool

### DIFF
--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -178,6 +178,7 @@ export default {
         { title: "Pedestrian Investigator", path: "/pedestrian-investigator" },
         { title: "Phase Plotter", path: "/phase-plotter" },
         { title: "Phase Start Table", path: "/phase-start-table" },
+        { title: "Start Up Loss Average", path: "/startup-loss-average" },
         { title: "High Res. Explainer", path: "/explainer" },
         { title: "Time Space Visualizer", path: "/gpx" },
         { title: "GPX & Phase Plotter", path: "/gpx-phase-plotter" },
@@ -213,6 +214,7 @@ export default {
         { title: "Pedestrian Investigator", path: "/pedestrian-investigator" },
         { title: "Phase Plotter", path: "/phase-plotter" },
         { title: "Phase Start Table", path: "/phase-start-table" },
+        { title: "Start Up Loss Average", path: "/startup-loss-average" },
         { title: "High Resolution Explainer", path: "/explainer" },
       ],
       TSgpxTools: [

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -30,6 +30,7 @@ import Dashboard from '../views/Dashboard'
 import VideoFrameExtractor from '../views/VideoFrameExtractor'
 import HighResPhaseStartTable from '../views/HighResPhaseStartTable'
 import PatternCalendar from '../views/PatternCalendar'
+import StartUpLossAverage from '../views/StartUpLossAverage'
 
 
 
@@ -179,6 +180,11 @@ const routes = [
         path: '/pattern-calendar',
         name: 'patternCalendar',
         component: PatternCalendar,
+    },
+    {
+        path: '/startup-loss-average',
+        name: 'startUpLossAverage',
+        component: StartUpLossAverage,
     },
     {
         path: '/PracticeExam',

--- a/src/views/About.vue
+++ b/src/views/About.vue
@@ -110,6 +110,12 @@ export default {
               path: "/phase-plotter",
             },
             {
+              title: "Start Up Loss Average",
+              description:
+                "Estimate start-up loss using green events and detector-off timestamps.",
+              path: "/startup-loss-average",
+            },
+            {
               title: "High Resolution Data Explainer",
               description:
                 "Explore event enumerations and how they map to controller behavior.",

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -116,6 +116,15 @@ export default {
         },
         {
           image:
+            "https://trafficsignalkit.s3.us-east-2.amazonaws.com/Photos/TrafficSignalKit.com+-+Inductance_detectors.jpg",
+          title: "Start Up Loss Average",
+          description:
+            "Estimate start-up loss from green intervals and detector-off events",
+          link: "/startup-loss-average",
+          topics: ["Controller Data", "Detection", "Performance"],
+        },
+        {
+          image:
             "https://trafficsignalkit.s3.us-east-2.amazonaws.com/Photos/trafficsignalkit.com+-+split+history+phase+termination+table.png",
           title: "High Resolution Split History",
           description: "Calculate Phase Durations from High Resolution Data",

--- a/src/views/StartUpLossAverage.vue
+++ b/src/views/StartUpLossAverage.vue
@@ -1,0 +1,398 @@
+<template>
+  <div class="startup-loss-tool">
+    <h1 class="h1-center-text">Start Up Loss Average</h1>
+    <p class="tool-intro">
+      Paste high-resolution controller data and a detector-to-phase mapping to
+      estimate start-up loss times. The tool matches each phase green event
+      (event code 1) with the first detector-off event (event code 81) on the
+      mapped detector channels. A per-phase fudge factor is subtracted to
+      account for vehicles clearing the detection zone.
+    </p>
+
+    <div class="input-grid">
+      <div class="input-card">
+        <h3>High-Resolution Data</h3>
+        <InputBox v-model="inputData" :defaultText="dataPlaceholder" />
+      </div>
+      <div class="input-card">
+        <h3>Detector Mapping &amp; Fudge Factor</h3>
+        <InputBox v-model="detectorMapInput" :defaultText="mappingPlaceholder" />
+      </div>
+    </div>
+
+    <div class="action-row">
+      <v-btn color="primary" :disabled="!canProcess" @click="processData">
+        Calculate Start-Up Loss
+      </v-btn>
+      <v-btn
+        color="secondary"
+        variant="tonal"
+        :disabled="!tableRows.length"
+        @click="resetResults"
+      >
+        Clear Results
+      </v-btn>
+    </div>
+
+    <v-card v-if="tableRows.length" class="results-card" variant="outlined">
+      <v-card-title>Start-Up Loss Summary by Phase</v-card-title>
+      <v-card-text>
+        <div class="table-wrapper">
+          <table class="summary-table">
+            <thead>
+              <tr>
+                <th>Phase</th>
+                <th>Fudge Factor (s)</th>
+                <th>Samples</th>
+                <th>Average Start-Up Loss (s)</th>
+                <th>Sample Losses (s)</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr v-for="row in tableRows" :key="`phase-${row.phase}`">
+                <td class="phase-cell">{{ row.phase }}</td>
+                <td>{{ formatSeconds(row.fudgeSeconds) }}</td>
+                <td>{{ row.samples.length }}</td>
+                <td>
+                  <span v-if="row.averageSeconds !== null">
+                    {{ formatSeconds(row.averageSeconds) }}
+                  </span>
+                  <span v-else>—</span>
+                </td>
+                <td>
+                  <div v-if="row.samples.length" class="sample-list">
+                    <div
+                      v-for="(sample, index) in row.samples"
+                      :key="`sample-${row.phase}-${index}`"
+                    >
+                      {{ formatSeconds(sample.adjustedSeconds) }}
+                      <span class="sample-meta">
+                        (G {{ sample.greenLabel }}, Det {{ sample.detector }})
+                      </span>
+                    </div>
+                  </div>
+                  <span v-else>—</span>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </v-card-text>
+    </v-card>
+  </div>
+</template>
+
+<script>
+import { DateTime } from "luxon";
+import InputBox from "../components/foundational/InputBox.vue";
+import convertTime from "../mixins/convertTime";
+
+const DISPLAY_FORMAT = "ccc, MMM d yyyy h:mm:ss.S a";
+
+export default {
+  name: "StartUpLossAverage",
+  components: { InputBox },
+  mixins: [convertTime],
+  data() {
+    return {
+      inputData: "",
+      detectorMapInput: "",
+      tableRows: [],
+      dataPlaceholder:
+        "timestamp, eventCode, parameter\n2024-03-14T08:00:00.100, 1, 2\n2024-03-14T08:00:02.300, 81, 12",
+      mappingPlaceholder:
+        "Detector, Phase, FudgeSeconds\n12, 2, 0.6\n15, 6, 0.8",
+    };
+  },
+  computed: {
+    canProcess() {
+      return this.inputData.trim().length > 0 && this.detectorMapInput.trim().length > 0;
+    },
+  },
+  methods: {
+    resetResults() {
+      this.tableRows = [];
+    },
+    processData() {
+      const mapping = this.parseDetectorMapping(this.detectorMapInput);
+      const events = this.parseHighResData(this.inputData);
+      if (!events.length || !mapping.phaseDetectors.size) {
+        this.tableRows = [];
+        return;
+      }
+
+      const detectorOffByChannel = this.groupDetectorOffEvents(events, 81);
+      const phaseGreenEvents = this.collectPhaseEvents(events, 1);
+      const phaseRedEvents = this.collectPhaseEvents(events, 10);
+
+      const phaseResults = new Map();
+
+      mapping.phaseDetectors.forEach((detectors, phase) => {
+        phaseResults.set(phase, {
+          phase,
+          fudgeSeconds: mapping.phaseFudge.get(phase) ?? 0,
+          samples: [],
+        });
+      });
+
+      phaseGreenEvents.forEach((greenEvents, phase) => {
+        const detectors = mapping.phaseDetectors.get(phase);
+        if (!detectors || !detectors.size) {
+          return;
+        }
+        const redEvents = phaseRedEvents.get(phase) || [];
+
+        greenEvents.forEach((greenMillis) => {
+          const endMillis =
+            this.findNextEventMillis(redEvents, greenMillis) ?? Number.POSITIVE_INFINITY;
+
+          let earliestOff = null;
+          let earliestDetector = null;
+
+          detectors.forEach((channel) => {
+            const detectorOffs = detectorOffByChannel.get(channel) || [];
+            const candidate = this.findFirstInRange(detectorOffs, greenMillis, endMillis);
+            if (candidate !== null && (earliestOff === null || candidate < earliestOff)) {
+              earliestOff = candidate;
+              earliestDetector = channel;
+            }
+          });
+
+          if (earliestOff === null) {
+            return;
+          }
+
+          const phaseResult = phaseResults.get(phase);
+          if (!phaseResult) {
+            return;
+          }
+
+          const rawSeconds = (earliestOff - greenMillis) / 1000;
+          const fudge = phaseResult.fudgeSeconds || 0;
+          const adjustedSeconds = Math.max(0, rawSeconds - fudge);
+
+          phaseResult.samples.push({
+            greenLabel: this.formatMillis(greenMillis),
+            detector: earliestDetector,
+            rawSeconds,
+            adjustedSeconds,
+          });
+        });
+      });
+
+      const tableRows = Array.from(phaseResults.values())
+        .map((row) => ({
+          ...row,
+          averageSeconds: this.calculateAverage(row.samples),
+        }))
+        .sort((a, b) => a.phase - b.phase);
+
+      this.tableRows = tableRows;
+    },
+    parseHighResData(input) {
+      return input
+        .split(/\r?\n/)
+        .map((line) => line.trim())
+        .filter(Boolean)
+        .map((line) => line.split(/[,\t]/).map((part) => part.trim()))
+        .filter((parts) => parts.length >= 3)
+        .map(([timestamp, eventCodeRaw, parameterRaw]) => {
+          const eventCode = Number(eventCodeRaw);
+          const parameter = Number(parameterRaw);
+          if (Number.isNaN(eventCode) || Number.isNaN(parameter)) {
+            return null;
+          }
+          const converted = this.convertTimestamp(timestamp);
+          if (!converted?.calculatable) {
+            return null;
+          }
+          return {
+            timestamp,
+            eventCode,
+            parameter,
+            millis: converted.MillisecFromEpoch,
+          };
+        })
+        .filter(Boolean)
+        .sort((a, b) => a.millis - b.millis);
+    },
+    parseDetectorMapping(input) {
+      const phaseDetectors = new Map();
+      const phaseFudge = new Map();
+
+      const lines = input
+        .split(/\r?\n/)
+        .map((line) => line.trim())
+        .filter(Boolean);
+
+      lines.forEach((line) => {
+        const numericParts = line.match(/-?\d+(?:\.\d+)?/g);
+        if (!numericParts || numericParts.length < 2) {
+          return;
+        }
+        const [detectorRaw, phaseRaw, fudgeRaw] = numericParts;
+        const detector = Number(detectorRaw);
+        const phase = Number(phaseRaw);
+        const fudge = fudgeRaw !== undefined ? Number(fudgeRaw) : 0;
+
+        if (Number.isNaN(detector) || Number.isNaN(phase)) {
+          return;
+        }
+
+        if (!phaseDetectors.has(phase)) {
+          phaseDetectors.set(phase, new Set());
+        }
+        phaseDetectors.get(phase).add(detector);
+        phaseFudge.set(phase, Number.isNaN(fudge) ? 0 : fudge);
+      });
+
+      return { phaseDetectors, phaseFudge };
+    },
+    collectPhaseEvents(events, eventCode) {
+      const phaseMap = new Map();
+      events
+        .filter((event) => event.eventCode === eventCode)
+        .forEach((event) => {
+          if (!phaseMap.has(event.parameter)) {
+            phaseMap.set(event.parameter, []);
+          }
+          phaseMap.get(event.parameter).push(event.millis);
+        });
+      phaseMap.forEach((list) => list.sort((a, b) => a - b));
+      return phaseMap;
+    },
+    groupDetectorOffEvents(events, eventCode) {
+      const detectorMap = new Map();
+      events
+        .filter((event) => event.eventCode === eventCode)
+        .forEach((event) => {
+          if (!detectorMap.has(event.parameter)) {
+            detectorMap.set(event.parameter, []);
+          }
+          detectorMap.get(event.parameter).push(event.millis);
+        });
+      detectorMap.forEach((list) => list.sort((a, b) => a - b));
+      return detectorMap;
+    },
+    findNextEventMillis(eventMillis, startMillis) {
+      const index = this.lowerBound(eventMillis, startMillis + 1);
+      if (index < eventMillis.length) {
+        return eventMillis[index];
+      }
+      return null;
+    },
+    findFirstInRange(list, start, end) {
+      if (!list.length) {
+        return null;
+      }
+      const index = this.lowerBound(list, start);
+      if (index < list.length && list[index] <= end) {
+        return list[index];
+      }
+      return null;
+    },
+    lowerBound(list, value) {
+      let low = 0;
+      let high = list.length;
+      while (low < high) {
+        const mid = Math.floor((low + high) / 2);
+        if (list[mid] < value) {
+          low = mid + 1;
+        } else {
+          high = mid;
+        }
+      }
+      return low;
+    },
+    calculateAverage(samples) {
+      if (!samples.length) {
+        return null;
+      }
+      const total = samples.reduce((sum, sample) => sum + sample.adjustedSeconds, 0);
+      return total / samples.length;
+    },
+    formatSeconds(value) {
+      return Number.isFinite(value) ? value.toFixed(2) : "—";
+    },
+    formatMillis(millis) {
+      return DateTime.fromMillis(millis).toFormat(DISPLAY_FORMAT);
+    },
+  },
+};
+</script>
+
+<style scoped>
+.startup-loss-tool {
+  padding: 16px 0 32px;
+}
+
+.tool-intro {
+  max-width: 860px;
+  margin: 0 auto 20px;
+  text-align: center;
+}
+
+.input-grid {
+  display: grid;
+  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  max-width: 1200px;
+  margin: 0 auto 16px;
+}
+
+.input-card {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.action-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  justify-content: center;
+  margin: 8px 0 16px;
+}
+
+.results-card {
+  max-width: 1100px;
+  margin: 0 auto;
+}
+
+.table-wrapper {
+  overflow-x: auto;
+}
+
+.summary-table {
+  width: 100%;
+  border-collapse: collapse;
+  text-align: left;
+}
+
+.summary-table th,
+.summary-table td {
+  padding: 12px 10px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+  vertical-align: top;
+}
+
+.summary-table th {
+  font-weight: 600;
+}
+
+.phase-cell {
+  font-weight: 600;
+}
+
+.sample-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.sample-meta {
+  color: rgba(255, 255, 255, 0.6);
+  font-size: 0.85rem;
+  margin-left: 6px;
+}
+</style>


### PR DESCRIPTION
### Motivation

- Provide a focused tool to estimate per-phase start-up loss times by matching high-resolution green events to detector-off events and allowing a per-phase fudge subtraction for vehicles clearing the detection zone.

### Description

- Add a new view `StartUpLossAverage` (`src/views/StartUpLossAverage.vue`) that parses high-resolution CSV/TSV controller logs and a detector-to-phase mapping (including a per-phase `FudgeSeconds`) and displays a per-phase summary table with samples and averages.
- Matching logic: the tool collects phase green events (event code `1`), finds the first detector-off event (event code `81`) on mapped detector channels before the next red event, computes raw delay, subtracts the configured per-phase fudge factor, and records adjusted samples and averages.
- Robust parsing and helpers: accept comma or tab separated input, return sorted millisecond timestamps for phase and detector events, add efficient search helpers (`lowerBound`, `findFirstInRange`, `findNextEventMillis`) and average calculation.
- Wire the tool into the app by registering the route (`/startup-loss-average`) in `src/router/index.js`, adding navigation entries in `src/components/Header.vue`, and listing the tool in `src/views/About.vue` and `src/views/Home.vue`.

### Testing

- Started the dev server with `npm run dev` and successfully served the app; the server reported ready and was reachable on the local network address (HTTP 200). (success)
- Automated UI check: used a Playwright script to navigate to `http://127.0.0.1:4173/startup-loss-average` and capture a screenshot of the new tool page; the script ran and produced `artifacts/startup-loss-average.png`. (success)
- No unit or integration test suites were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697aed4edc74832b8aea3f85eb460acd)