### PR TITLE
Add per-row GIF downloads for CSV-extracted clips

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@xmldom/xmldom": "^0.8.10",
         "chart.js": "^4.4.3",
         "chartjs-plugin-zoom": "^2.0.1",
+        "gifshot": "^0.4.5",
         "gpx-parser-builder": "^1.1.0",
         "gpxparser": "^3.0.8",
         "html2canvas": "^1.4.1",
@@ -3001,6 +3002,12 @@
       "dependencies": {
         "assert-plus": "^1.0.0"
       }
+    },
+    "node_modules/gifshot": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/gifshot/-/gifshot-0.4.5.tgz",
+      "integrity": "sha512-oaOTT7patjxFFv7ptR0R0NNhqy3ZAmcLUQCjM/sTsvsQaUAlB2fHirLajcNAKJ6ufoVhdP+ZkXYvmUycHP1FNg==",
+      "license": "MIT"
     },
     "node_modules/gifwrap": {
       "version": "0.9.4",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@xmldom/xmldom": "^0.8.10",
     "chart.js": "^4.4.3",
     "chartjs-plugin-zoom": "^2.0.1",
+    "gifshot": "^0.4.5",
     "gpx-parser-builder": "^1.1.0",
     "gpxparser": "^3.0.8",
     "html2canvas": "^1.4.1",


### PR DESCRIPTION
### Motivation

- Provide a quick per-row GIF preview/download that shows ~1s before and after each CSV timestamp to aid visual review of events.
- Keep generated GIFs lightweight and browser-native without adding heavy backend work by encoding them client-side.
- Ensure generated GIF object URLs are tracked and revoked to avoid leaking memory during refresh/unmount.

### Description

- Added the `gifshot` dependency and imported it into `VideoFrameExtractor.vue` to encode GIFs in-browser.
- Implemented `extractGifClipAtTime(targetTime, row)` which clamps `startTime`/`endTime` to ±1s around `targetTime`, samples frames at a capped FPS (max 12), encodes frames into a GIF via `gifshot.createGIF`, creates a blob URL, and returns `{ gifUrl, gifFilename, gifError }`.
- Added `buildCsvGifFilename(row)` to generate a sensible GIF filename and `revokeCsvGifUrls()` to revoke previously-created GIF object URLs; wired cleanup into `handleFileChange()`, `queueCsvExtraction()`, and `beforeUnmount()`.
- Updated CSV extraction flow to call `extractGifClipAtTime` per row and store `gifUrl`, `gifFilename`, and `gifError` on each `csvFrames` entry; updated the table header and cell UI to show both "Download PNG" and "Download GIF" links and added `.csv-downloads` CSS.

### Testing

- Installed the new dependency with `npm install gifshot@^0.4.5`, which completed successfully.
- Started the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` to validate the app launched, but an automated Playwright screenshot attempt failed due to the headless browser crashing in the container, so end-to-end UI capture did not complete.
- No unit tests were present or added; manual/local testing of extracting frames and GIF generation is recommended due to the environment Playwright limitation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697c30206378832bacbca91a8cb091be)