### PR TITLE
Add controls to position download button in Video Frame Extractor preview

### DIFF
--- a/src/views/VideoFrameExtractor.vue
+++ b/src/views/VideoFrameExtractor.vue
@@ -178,8 +178,48 @@
     <canvas ref="canvas" class="frame-canvas"></canvas>
 
     <section class="preview" v-if="frameDataUrl">
+      <div class="preview-controls" role="group" aria-label="Download button position">
+        <span class="preview-controls-label">Download button position</span>
+        <label class="preview-radio">
+          <input
+            v-model="downloadButtonPosition"
+            type="radio"
+            value="top-left"
+          />
+          Top left
+        </label>
+        <label class="preview-radio">
+          <input
+            v-model="downloadButtonPosition"
+            type="radio"
+            value="top-right"
+          />
+          Top right
+        </label>
+        <label class="preview-radio">
+          <input
+            v-model="downloadButtonPosition"
+            type="radio"
+            value="bottom-left"
+          />
+          Bottom left
+        </label>
+        <label class="preview-radio">
+          <input
+            v-model="downloadButtonPosition"
+            type="radio"
+            value="bottom-right"
+          />
+          Bottom right
+        </label>
+      </div>
       <div class="preview-image">
-        <a class="download-button" :href="frameDataUrl" :download="downloadFilename">
+        <a
+          class="download-button"
+          :class="downloadButtonPosition"
+          :href="frameDataUrl"
+          :download="downloadFilename"
+        >
           Download frame
         </a>
         <img :src="frameDataUrl" alt="Extracted video frame preview" />
@@ -278,6 +318,7 @@ export default {
       csvProcessing: false,
       csvJobId: 0,
       enableGifDownloads: false,
+      downloadButtonPosition: "top-right",
     };
   },
   computed: {
@@ -1292,6 +1333,35 @@ export default {
   width: min(880px, 100%);
 }
 
+.preview-controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px 14px;
+  margin-bottom: 12px;
+  padding: 10px 12px;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.7);
+  border: 1px solid rgba(0, 0, 0, 0.08);
+}
+
+.preview-controls-label {
+  font-weight: 600;
+  color: #335250;
+}
+
+.preview-radio {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.95rem;
+  color: #2f3f3d;
+}
+
+.preview-radio input {
+  accent-color: #00796b;
+}
+
 .preview-image {
   position: relative;
   display: block;
@@ -1322,6 +1392,34 @@ export default {
 .download-button:hover {
   transform: translateY(-1px);
   box-shadow: 0 10px 20px rgba(0, 150, 136, 0.2);
+}
+
+.download-button.top-left {
+  top: 12px;
+  right: auto;
+  bottom: auto;
+  left: 12px;
+}
+
+.download-button.top-right {
+  top: 12px;
+  right: 12px;
+  bottom: auto;
+  left: auto;
+}
+
+.download-button.bottom-left {
+  top: auto;
+  right: auto;
+  bottom: 12px;
+  left: 12px;
+}
+
+.download-button.bottom-right {
+  top: auto;
+  right: 12px;
+  bottom: 12px;
+  left: auto;
 }
 
 .csv-output {


### PR DESCRIPTION
### Motivation
- Provide a simple UI to move the preview "Download frame" button to any corner so users can avoid overlapping important parts of the extracted image. 

### Description
- Add a radio control group above the preview image to choose the download button corner and expose it via `downloadButtonPosition` in component `data()` with default `"top-right"` in `src/views/VideoFrameExtractor.vue`. 
- Bind the selected value as a CSS class on the download anchor and add corner-specific CSS helpers (`.download-button.top-left`, `.top-right`, `.bottom-left`, `.bottom-right`) so the button repositions accordingly. 
- Add styles for the new control group (`.preview-controls`, `.preview-controls-label`, `.preview-radio`) and include `role="group"` and an accessible label for the control set. 

### Testing
- Started the dev server with `npm run dev -- --host 0.0.0.0 --port 4173`, which failed to serve the app due to an unresolved dependency error for `gifshot`. (failed) 
- Attempted an automated Playwright screenshot against `http://127.0.0.1:4173/video-frame-extractor`, which failed because the server was not available. (failed)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697c35db6438832b8d28aa5206b8aad5)