### PR TITLE
Basic Timing Seeker: hide all-zero phases, add vehicle recall dropdown, compact recall selects

### DIFF
--- a/src/views/BasicTimingSeeker.vue
+++ b/src/views/BasicTimingSeeker.vue
@@ -184,7 +184,16 @@ Example input:
                   class="table-input"
                 />
               </td>
-              <td>{{ row.veh_recall_type }}</td>
+              <td>
+                <v-select
+                  v-model="row.veh_recall_type"
+                  :items="vehRecallOptions"
+                  density="compact"
+                  variant="outlined"
+                  hide-details
+                  class="table-select"
+                />
+              </td>
               <td>
                 <v-select
                   v-model="row.ped_recall"
@@ -192,7 +201,7 @@ Example input:
                   density="compact"
                   variant="outlined"
                   hide-details
-                  class="table-input"
+                  class="table-select"
                 />
               </td>
             </tr>
@@ -235,6 +244,7 @@ export default {
       processedRows: [],
       errorMessage: "",
       booleanOptions: [true, false],
+      vehRecallOptions: ["None", "Min", "Max", "Soft"],
       csvHeaders: [
         "phase",
         "signal_id",
@@ -312,6 +322,20 @@ export default {
             [EVENT_CODES.PED_WALK],
             [EVENT_CODES.BEGIN_GREEN],
           );
+
+          const hasTiming = [
+            minGreen,
+            maxGreen,
+            yellow,
+            allRed,
+            pedWalk,
+            pedClearance,
+            lpi,
+          ].some((value) => value > 0);
+
+          if (!hasTiming) {
+            return;
+          }
 
           rows.push({
             phase: Number(phase),
@@ -487,6 +511,13 @@ export default {
 }
 .table-input {
   min-width: 110px;
+}
+.table-select {
+  min-width: 110px;
+}
+.table-select .v-field__input,
+.table-select .v-select__selection {
+  font-size: 0.75rem;
 }
 .muted {
   color: rgba(0, 0, 0, 0.6);


### PR DESCRIPTION
### Motivation
- Avoid showing phases in the Basic Timing Seeker table that have no measured timing (all green/yellow/ped/all-red values are zero) to reduce noise.
- Make the pedestrian recall control clearly editable as a dropdown and reduce its text size so it fits the compact table layout.
- Allow selecting a vehicle recall type (`None`, `Min`, `Max`, `Soft`) instead of rendering it as plain text so the value can be edited.

### Description
- Updated `src/views/BasicTimingSeeker.vue` to compute `hasTiming` for each phase and skip adding rows where all timing values are zero.
- Replaced the vehicular recall cell text with a `v-select` bound to a new `vehRecallOptions` array (`["None","Min","Max","Soft"]`).
- Switched the ped recall select to use a new `.table-select` class and added `.table-select` CSS with a smaller font (`0.75rem`) to make dropdown text more compact and visible.
- Kept existing CSV generation and defaults; rows that are skipped are simply not included in `processedRows`.

### Testing
- Started the dev server using `npm run dev` (Vite) and confirmed the app served HTML (HTTP 200). — succeeded.
- Captured a UI screenshot of `/#/basic-timing-seeker` with a Playwright script to verify the table and dropdowns rendered; the screenshot artifact was produced. — succeeded.
- No automated unit tests were modified or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697c45b0eb1c832ba986a860f9df0a30)