### PR TITLE
Add Skipped Phase Finder tool for detector calls

### DIFF
--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -180,6 +180,7 @@ export default {
         { title: "Phase Start Table", path: "/phase-start-table" },
         { title: "Start Up Loss Average", path: "/startup-loss-average" },
         { title: "Time to Reduce", path: "/time-to-reduce" },
+        { title: "Skipped Phase Finder", path: "/skipped-phase-finder" },
         { title: "High Res. Explainer", path: "/explainer" },
         { title: "Time Space Visualizer", path: "/gpx" },
         { title: "GPX & Phase Plotter", path: "/gpx-phase-plotter" },
@@ -219,6 +220,7 @@ export default {
         { title: "Start Up Loss Average", path: "/startup-loss-average" },
         { title: "High Resolution Explainer", path: "/explainer" },
         { title: "Time to Reduce", path: "/time-to-reduce" },
+        { title: "Skipped Phase Finder", path: "/skipped-phase-finder" },
         { title: "Basic Timing Seeker", path: "/basic-timing-seeker" },
       ],
       TSgpxTools: [

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -33,6 +33,7 @@ import PatternCalendar from '../views/PatternCalendar'
 import BasicTimingSeeker from '../views/BasicTimingSeeker'
 import StartUpLossAverage from '../views/StartUpLossAverage'
 import TimeToReduce from '../views/TimeToReduce'
+import SkippedPhaseFinder from '../views/SkippedPhaseFinder'
 
 
 
@@ -198,6 +199,11 @@ const routes = [
         path: '/time-to-reduce',
         name: 'timeToReduce',
         component: TimeToReduce,
+    },
+    {
+        path: '/skipped-phase-finder',
+        name: 'skippedPhaseFinder',
+        component: SkippedPhaseFinder,
     },
     {
         path: '/PracticeExam',

--- a/src/seo/routes.js
+++ b/src/seo/routes.js
@@ -149,6 +149,12 @@ export const routeMeta = {
       "Estimate call delays between detector actuations and phase service.",
     path: "/delay-estimator",
   },
+  skippedPhaseFinder: {
+    title: "Skipped Phase Finder | Detector Calls Without Service",
+    description:
+      "Identify detector on events where the assigned phase is not served within two minutes.",
+    path: "/skipped-phase-finder",
+  },
   signalOffsets: {
     title: "Signal Offset Calculator | Coordinated Phase Alignment",
     description:

--- a/src/views/About.vue
+++ b/src/views/About.vue
@@ -128,6 +128,12 @@ export default {
               path: "/time-to-reduce",
             },
             {
+              title: "Skipped Phase Finder",
+              description:
+                "Find detector calls where the assigned phase is not served within two minutes.",
+              path: "/skipped-phase-finder",
+            },
+            {
               title: "High Resolution Data Explainer",
               description:
                 "Explore event enumerations and how they map to controller behavior.",

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -90,6 +90,15 @@ export default {
         },
         {
           image:
+            "https://trafficsignalkit.s3.us-east-2.amazonaws.com/Photos/TrafficSignalKit.com+-+Inductance_detectors.jpg",
+          title: "Skipped Phase Finder",
+          description:
+            "Find detector calls where the phase is not served within two minutes",
+          link: "/skipped-phase-finder",
+          topics: ["Controller Data", "Detection", "Diagnostics"],
+        },
+        {
+          image:
             "https://trafficsignalkit.s3.us-east-2.amazonaws.com/Photos/TrafficSignalkit.com+-+All+Enumerations+Plot.png",
           title: "Timeseries Plot All Enumerations",
           description: "Plot preemption (101-119) enumeration events over time",

--- a/src/views/SkippedPhaseFinder.vue
+++ b/src/views/SkippedPhaseFinder.vue
@@ -1,0 +1,352 @@
+<template>
+  <div class="skipped-phase-tool">
+    &nbsp;
+    <h1 class="h1-center-text">Skipped Phase Finder</h1>
+
+    <div class="left-justify-text">
+      <v-expansion-panels v-model="panel" multiple>
+        <v-expansion-panel title="About: Skipped Phase Finder" value="about">
+          <v-expansion-panel-text>
+            This tool scans high-resolution controller data for detector on
+            events and checks whether the assigned phase is served within
+            two minutes. It is useful for spotting missed calls or phases that
+            are starving despite demand.
+          </v-expansion-panel-text>
+        </v-expansion-panel>
+        <v-expansion-panel title="Inputs Needed" value="inputs">
+          <v-expansion-panel-text>
+            Provide two CSV inputs:
+            <ul>
+              <li>
+                High-resolution events as
+                <b>timestamp, event code, parameter</b> (phase or detector
+                channel depending on the event). Example:
+                <code>1/6/2024 15:00:03.3, 82, 12</code>
+              </li>
+              <li>
+                Detector assignments as <b>phase, detector channel</b>.
+                Labels like <code>Det 1</code> are accepted.
+                Example: <code>6, 12</code>
+              </li>
+            </ul>
+          </v-expansion-panel-text>
+        </v-expansion-panel>
+      </v-expansion-panels>
+    </div>
+
+    <v-card class="mt-6" variant="outlined">
+      <v-card-text>
+        <div class="input-section">
+          <div>
+            <h3>High-Resolution Event Data</h3>
+            <InputBox v-model="inputData" :default-text="defaultText" />
+          </div>
+          <div>
+            <h3>Detector Assignments</h3>
+            <InputBox
+              v-model="assignmentData"
+              :default-text="assignmentPlaceholder"
+            />
+          </div>
+        </div>
+
+        <div class="action-row">
+          <v-btn color="primary" :disabled="!canProcess" @click="processData">
+            Find Skipped Phases
+          </v-btn>
+          <p v-if="errorMessage" class="error-message">{{ errorMessage }}</p>
+        </div>
+      </v-card-text>
+    </v-card>
+
+    <v-card v-if="results.length" class="mt-6" variant="outlined">
+      <v-card-text>
+        <h2>Skipped Phase Events</h2>
+        <p class="muted">
+          Detector on events where the assigned phase was not served within
+          120 seconds.
+        </p>
+        <v-table density="compact" class="mt-4">
+          <thead>
+            <tr>
+              <th>Detector On Time</th>
+              <th>Phase</th>
+              <th>Detector</th>
+              <th>Next Green</th>
+              <th>Wait (sec)</th>
+              <th>Description</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="row in results" :key="row.id">
+              <td>{{ row.detectorOn }}</td>
+              <td>{{ row.phase }}</td>
+              <td>{{ row.detector }}</td>
+              <td>{{ row.nextGreen }}</td>
+              <td>{{ row.waitSeconds ?? "—" }}</td>
+              <td>{{ row.description }}</td>
+            </tr>
+          </tbody>
+        </v-table>
+      </v-card-text>
+    </v-card>
+
+    <v-card v-else-if="processed" class="mt-6" variant="outlined">
+      <v-card-text>
+        <p class="empty-state">
+          No skipped phase events were found in the current inputs.
+        </p>
+      </v-card-text>
+    </v-card>
+  </div>
+</template>
+
+<script>
+import InputBox from "../components/foundational/InputBox.vue";
+import convertTime from "../mixins/convertTime";
+
+const EVENT_CODES = {
+  BEGIN_GREEN: 1,
+  DETECTOR_ON: 82,
+};
+
+export default {
+  name: "SkippedPhaseFinder",
+  components: {
+    InputBox,
+  },
+  mixins: [convertTime],
+  data() {
+    return {
+      panel: [],
+      inputData: "",
+      assignmentData: "",
+      results: [],
+      errorMessage: "",
+      processed: false,
+      defaultText:
+        "Paste high-resolution data: timestamp, event code, parameter",
+      assignmentPlaceholder:
+        "Paste detector assignments: phase, detector channel. Labels like 'Det 1' are supported.",
+    };
+  },
+  computed: {
+    canProcess() {
+      return this.inputData.trim().length > 0 && this.assignmentData.trim().length > 0;
+    },
+  },
+  methods: {
+    processData() {
+      this.processed = true;
+      this.errorMessage = "";
+      this.results = [];
+
+      const events = this.parseEvents();
+      if (!events.length) {
+        this.errorMessage = "No valid high-resolution events were found.";
+        return;
+      }
+
+      const assignments = this.parseAssignments();
+      if (!assignments.size) {
+        this.errorMessage =
+          "No detector assignments were found. Provide phase, detector pairs.";
+        return;
+      }
+
+      const greenEventsByPhase = this.collectGreenEvents(events);
+      const detectorEvents = events.filter(
+        (event) => event.eventCode === EVENT_CODES.DETECTOR_ON,
+      );
+
+      const results = [];
+      detectorEvents.forEach((event) => {
+        const phases = assignments.get(event.parameter) || [];
+        if (!phases.length) {
+          return;
+        }
+        phases.forEach((phase) => {
+          const nextGreen = this.findNextGreen(
+            greenEventsByPhase.get(phase),
+            event.millis,
+          );
+          const waitSeconds = nextGreen
+            ? (nextGreen.millis - event.millis) / 1000
+            : null;
+          if (waitSeconds === null || waitSeconds > 120) {
+            results.push({
+              id: `${event.millis}-${phase}-${event.parameter}`,
+              detectorOn: event.displayTime,
+              detectorOnMillis: event.millis,
+              phase,
+              detector: event.parameter,
+              nextGreen: nextGreen ? nextGreen.displayTime : "—",
+              waitSeconds:
+                waitSeconds === null ? null : Number(waitSeconds.toFixed(1)),
+              description: this.buildDescription({
+                phase,
+                detector: event.parameter,
+                detectorOn: event.displayTime,
+                nextGreen: nextGreen ? nextGreen.displayTime : null,
+                waitSeconds,
+              }),
+            });
+          }
+        });
+      });
+
+      this.results = results.sort(
+        (a, b) => a.detectorOnMillis - b.detectorOnMillis,
+      );
+    },
+    parseEvents() {
+      if (!this.inputData) {
+        return [];
+      }
+      return this.inputData
+        .split(/\r?\n/)
+        .map((line) => line.trim())
+        .filter(Boolean)
+        .map((line) => {
+          const parts = line.split(",").map((value) => value.trim());
+          if (parts.length < 3) {
+            return null;
+          }
+          const [timestampRaw, eventCodeRaw, parameterRaw] = parts;
+          const eventCode = Number(eventCodeRaw);
+          const parameter = this.parseNumberFromText(parameterRaw);
+          if (Number.isNaN(eventCode) || Number.isNaN(parameter)) {
+            return null;
+          }
+          const converted = this.convertTimestamp(timestampRaw || "");
+          if (!converted?.MillisecFromEpoch) {
+            return null;
+          }
+          return {
+            millis: converted.MillisecFromEpoch,
+            displayTime: converted.humanReadable || timestampRaw,
+            eventCode,
+            parameter,
+          };
+        })
+        .filter(Boolean)
+        .sort((a, b) => a.millis - b.millis);
+    },
+    parseAssignments() {
+      if (!this.assignmentData) {
+        return new Map();
+      }
+      const assignments = new Map();
+      this.assignmentData
+        .split(/\r?\n/)
+        .map((line) => line.trim())
+        .filter(Boolean)
+        .forEach((line) => {
+          const parts = line.split(/[\t,]/).map((value) => value.trim());
+          if (parts.length < 2) {
+            return;
+          }
+          const phase = this.parseNumberFromText(parts[0]);
+          const detector = this.parseNumberFromText(parts[1]);
+          if (Number.isNaN(phase) || Number.isNaN(detector)) {
+            return;
+          }
+          if (!assignments.has(detector)) {
+            assignments.set(detector, new Set());
+          }
+          assignments.get(detector).add(phase);
+        });
+      const normalized = new Map();
+      assignments.forEach((phases, detector) => {
+        normalized.set(detector, Array.from(phases).sort((a, b) => a - b));
+      });
+      return normalized;
+    },
+    collectGreenEvents(events) {
+      const phaseMap = new Map();
+      events
+        .filter((event) => event.eventCode === EVENT_CODES.BEGIN_GREEN)
+        .forEach((event) => {
+          if (!phaseMap.has(event.parameter)) {
+            phaseMap.set(event.parameter, []);
+          }
+          phaseMap.get(event.parameter).push(event);
+        });
+      phaseMap.forEach((phaseEvents) => {
+        phaseEvents.sort((a, b) => a.millis - b.millis);
+      });
+      return phaseMap;
+    },
+    findNextGreen(events, startMillis) {
+      if (!events || !events.length) {
+        return null;
+      }
+      return events.find((event) => event.millis > startMillis) || null;
+    },
+    buildDescription({ phase, detector, detectorOn, nextGreen, waitSeconds }) {
+      if (waitSeconds === null) {
+        return `Detector ${detector} called Phase ${phase} at ${detectorOn}, but no green event was found after the call.`;
+      }
+      return `Detector ${detector} called Phase ${phase} at ${detectorOn}. Next green was ${nextGreen} (${waitSeconds.toFixed(
+        1,
+      )} sec later).`;
+    },
+    parseNumberFromText(value) {
+      if (value === null || value === undefined) {
+        return Number.NaN;
+      }
+      const trimmed = String(value).trim();
+      if (!trimmed) {
+        return Number.NaN;
+      }
+      const numeric = Number(trimmed);
+      if (!Number.isNaN(numeric)) {
+        return numeric;
+      }
+      const match = trimmed.match(/-?\d+(\.\d+)?/);
+      return match ? Number(match[0]) : Number.NaN;
+    },
+  },
+};
+</script>
+
+<style scoped>
+.skipped-phase-tool {
+  text-align: left;
+}
+
+.left-justify-text {
+  margin: 0;
+  padding: 0;
+  text-align: left;
+}
+
+.input-section {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 24px;
+}
+
+.action-row {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 16px;
+  margin-top: 16px;
+}
+
+.error-message {
+  color: #c62828;
+  margin: 0;
+}
+
+.muted {
+  color: rgba(0, 0, 0, 0.6);
+  margin-top: 4px;
+}
+
+.empty-state {
+  margin: 0;
+  color: rgba(0, 0, 0, 0.6);
+}
+</style>


### PR DESCRIPTION
### Motivation
- Provide a focused tool to detect detector-on events that do not result in the assigned phase being served within two minutes, helping spot missed calls or starving phases.

### Description
- Add a new Vue view `SkippedPhaseFinder.vue` that accepts high-resolution event CSV and detector-to-phase assignment CSV inputs, parses timestamps with the existing `convertTime` mixin, and reports detector-on events where the assigned phase is not served within 120 seconds.
- Implement detection logic that collects phase `BEGIN_GREEN` events, finds the next green after each detector-on, computes wait time, and builds a results table with timestamp, phase, detector, next green time, wait seconds, and a human-friendly description.
- Wire the tool into the app by registering the new route at `/skipped-phase-finder`, adding the tool to the main navigation and relevant tool lists (`Header.vue`, `Home.vue`, `About.vue`), and adding SEO metadata in `src/seo/routes.js`.

### Testing
- Started the dev server with `npm run dev` and verified the app served successfully (Vite reported ready); this service responded with `HTTP/1.1 200 OK` for the new route.
- Captured a full-page screenshot of the new route using Playwright to verify UI rendering; the screenshot artifact was produced successfully.
- Performed automated smoke verification by requesting `GET /skipped-phase-finder` (`curl -I`) which returned `200 OK`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ccd14c4f4832bbbf87e918b25ec92)