### PR TITLE
Refine Cabinet PM Scheduler: CSV GTSS input, per-row frequencies, and maps

### DIFF
--- a/src/components/Header.vue
+++ b/src/components/Header.vue
@@ -193,6 +193,7 @@ export default {
         { title: "Message Sign Designer", path: "/message-sign-designer" },
         { title: "Video Frame Extractor", path: "/video-frame-extractor" },
         { title: "Basic Timing Seeker", path: "/basic-timing-seeker" },
+        { title: "Cabinet PM Scheduler", path: "/cabinet-pm-scheduler" },
         { title: "Reference", path: "/reference" },
         { title: "Practice Exam", path: "/practice-exam" },
         { title: "About", path: "/about" },
@@ -222,6 +223,7 @@ export default {
         { title: "Time to Reduce", path: "/time-to-reduce" },
         { title: "Skipped Phase Finder", path: "/skipped-phase-finder" },
         { title: "Basic Timing Seeker", path: "/basic-timing-seeker" },
+        { title: "Cabinet PM Scheduler", path: "/cabinet-pm-scheduler" },
       ],
       TSgpxTools: [
         { title: "Time Space Visualizer", path: "/gpx" },
@@ -238,6 +240,7 @@ export default {
         { title: "Message Sign Designer", path: "/message-sign-designer" },
         { title: "Video Frame Extractor", path: "/video-frame-extractor" },
         { title: "Basic Timing Seeker", path: "/basic-timing-seeker" },
+        { title: "Cabinet PM Scheduler", path: "/cabinet-pm-scheduler" },
         { title: "Reference", path: "/reference" },
         { title: "Practice Exam", path: "/practice-exam" },
       ],

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -34,6 +34,7 @@ import BasicTimingSeeker from '../views/BasicTimingSeeker'
 import StartUpLossAverage from '../views/StartUpLossAverage'
 import TimeToReduce from '../views/TimeToReduce'
 import SkippedPhaseFinder from '../views/SkippedPhaseFinder'
+import TrafficSignalCabinetPMScheduler from '../views/TrafficSignalCabinetPMScheduler'
 
 
 
@@ -204,6 +205,11 @@ const routes = [
         path: '/skipped-phase-finder',
         name: 'skippedPhaseFinder',
         component: SkippedPhaseFinder,
+    },
+    {
+        path: '/cabinet-pm-scheduler',
+        name: 'cabinetPMScheduler',
+        component: TrafficSignalCabinetPMScheduler,
     },
     {
         path: '/PracticeExam',

--- a/src/seo/routes.js
+++ b/src/seo/routes.js
@@ -77,6 +77,12 @@ export const routeMeta = {
       "Simulate basic intersection operations to understand gap-out/max-out behavior.",
     path: "/traffic-simulator",
   },
+  cabinetPMScheduler: {
+    title: "Traffic Signal Cabinet PM Scheduler | Preventative Maintenance",
+    description:
+      "Schedule preventative maintenance visits for signal cabinets with technician assignments and adjustable frequencies.",
+    path: "/cabinet-pm-scheduler",
+  },
   phasePlotter: {
     title: "Signal Phase Plotter | Red-Green-Yellow Visualization",
     description:

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -134,6 +134,15 @@ export default {
         },
         {
           image:
+            "https://trafficsignalkit.s3.us-east-2.amazonaws.com/Photos/TrafficSignalKit.com+-+Offset+Calculation.png",
+          title: "Traffic Signal Cabinet PM Scheduler",
+          description:
+            "Plan preventative maintenance visits by technician and frequency.",
+          link: "/cabinet-pm-scheduler",
+          topics: ["Maintenance", "Scheduling", "Cabinets"],
+        },
+        {
+          image:
             "https://trafficsignalkit.s3.us-east-2.amazonaws.com/Photos/trafficsignalkit.com+-+split+history+phase+termination+table.png",
           title: "High Resolution Split History",
           description: "Calculate Phase Durations from High Resolution Data",

--- a/src/views/TrafficSignalCabinetPMScheduler.vue
+++ b/src/views/TrafficSignalCabinetPMScheduler.vue
@@ -1,0 +1,373 @@
+<template>
+  <v-container class="tool-container">
+    <h1 class="h1-center-text">Traffic Signal Cabinet PM Scheduler</h1>
+    <v-card class="tool-card" elevation="2">
+      <v-card-text>
+        <p class="tool-intro">
+          Paste GTSS-formatted signal locations (from
+          <a href="https://gtss.dev" target="_blank" rel="noopener">gtss.dev</a>),
+          set the technician count, and choose default preventative maintenance
+          frequencies. Adjust individual cabinet frequencies, then rebuild the
+          schedule to assign each visit by month.
+        </p>
+        <v-row>
+          <v-col cols="12" md="6">
+            <label class="input-label">GTSS Signal List</label>
+            <InputBox
+              v-model="signalsInput"
+              :default-text="defaultSignals"
+            />
+          </v-col>
+          <v-col cols="12" md="6">
+            <v-card class="settings-card" variant="outlined">
+              <v-card-text>
+                <v-text-field
+                  v-model.number="technicianCount"
+                  type="number"
+                  min="1"
+                  label="Number of technicians"
+                  variant="outlined"
+                  density="comfortable"
+                />
+                <v-select
+                  v-model.number="defaultFrequency"
+                  :items="frequencyOptions"
+                  item-title="label"
+                  item-value="value"
+                  label="Default frequency (months)"
+                  variant="outlined"
+                  density="comfortable"
+                />
+                <v-btn
+                  color="primary"
+                  class="mt-2"
+                  @click="rebuildSchedule"
+                >
+                  Rebuild schedule
+                </v-btn>
+              </v-card-text>
+            </v-card>
+          </v-col>
+        </v-row>
+      </v-card-text>
+    </v-card>
+
+    <v-card class="tool-card" elevation="2">
+      <v-card-title class="section-title">Cabinet Frequencies</v-card-title>
+      <v-card-text>
+        <p v-if="signalRows.length === 0" class="muted-text">
+          Add GTSS signal lines to generate cabinet frequency controls.
+        </p>
+        <v-table v-else class="cabinet-table">
+          <thead>
+            <tr>
+              <th>Signal</th>
+              <th>Agency</th>
+              <th>Latitude</th>
+              <th>Longitude</th>
+              <th>Frequency</th>
+              <th>Map</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="signal in signalRows" :key="signal.key">
+              <td class="signal-id">{{ signal.signalId }}</td>
+              <td>{{ signal.agencyId }}</td>
+              <td>{{ signal.latitude }}</td>
+              <td>{{ signal.longitude }}</td>
+              <td class="frequency-cell">
+                <v-select
+                  v-model.number="frequencyOverrides[signal.key]"
+                  :items="frequencyOptions"
+                  item-title="label"
+                  item-value="value"
+                  label="Frequency"
+                  density="comfortable"
+                  variant="outlined"
+                  hide-details
+                />
+              </td>
+              <td>
+                <div class="map-box">
+                  <iframe
+                    :src="signal.mapUrl"
+                    loading="lazy"
+                    title="Signal map"
+                  ></iframe>
+                </div>
+              </td>
+            </tr>
+          </tbody>
+        </v-table>
+      </v-card-text>
+    </v-card>
+
+    <v-card class="tool-card" elevation="2">
+      <v-card-title class="section-title">Monthly Technician Schedule</v-card-title>
+      <v-card-text>
+        <p v-if="scheduleRows.length === 0" class="muted-text">
+          Enter signals and click “Rebuild schedule” to populate the table.
+        </p>
+        <v-table v-else class="schedule-table">
+          <thead>
+            <tr>
+              <th>Technician</th>
+              <th v-for="month in months" :key="month">{{ month }}</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="row in scheduleRows" :key="row.name">
+              <td class="tech-name">{{ row.name }}</td>
+              <td v-for="month in months" :key="month">
+                <ul v-if="row.assignments[month].length" class="assignment-list">
+                  <li v-for="cabinet in row.assignments[month]" :key="cabinet">
+                    {{ cabinet }}
+                  </li>
+                </ul>
+                <span v-else class="muted-text">—</span>
+              </td>
+            </tr>
+          </tbody>
+        </v-table>
+      </v-card-text>
+    </v-card>
+  </v-container>
+</template>
+
+<script>
+import InputBox from "@/components/foundational/InputBox.vue";
+
+export default {
+  name: "TrafficSignalCabinetPMScheduler",
+  components: {
+    InputBox,
+  },
+  data() {
+    return {
+      defaultSignals:
+        "signal_id,agency_id,latitude,longitude\n16,WC,37.92745102883522,-122.01467865377727\n2,WC,37.90499423048438,-122.06572811915521\n3,WC,37.906184628902054,-122.06432758290217\n28,WC,37.89260882839668,-122.06111411892594\n43,WC,37.89737707796012,-122.05995082855226\n36,WC,37.91166672982153,-122.06015467643739",
+      signalsInput: "",
+      technicianCount: 3,
+      defaultFrequency: 3,
+      frequencyOverrides: {},
+      scheduleRows: [],
+      months: [
+        "Jan",
+        "Feb",
+        "Mar",
+        "Apr",
+        "May",
+        "Jun",
+        "Jul",
+        "Aug",
+        "Sep",
+        "Oct",
+        "Nov",
+        "Dec",
+      ],
+      frequencyOptions: [
+        { label: "Monthly", value: 1 },
+        { label: "Every 2 months", value: 2 },
+        { label: "Quarterly", value: 3 },
+        { label: "Every 4 months", value: 4 },
+        { label: "Semiannual", value: 6 },
+        { label: "Annual", value: 12 },
+      ],
+    };
+  },
+  computed: {
+    signalRows() {
+      const text = this.signalsInput || this.defaultSignals;
+      const rows = this.parseSignals(text);
+      return rows.map((row) => ({
+        ...row,
+        frequency: this.getFrequencyForSignal(row.key),
+        mapUrl: this.buildMapUrl(row.latitude, row.longitude),
+      }));
+    },
+  },
+  watch: {
+    defaultFrequency() {
+      this.rebuildSchedule();
+    },
+    technicianCount() {
+      this.rebuildSchedule();
+    },
+    signalsInput() {
+      this.initializeOverrides();
+    },
+  },
+  mounted() {
+    this.initializeOverrides();
+    this.rebuildSchedule();
+  },
+  methods: {
+    parseSignals(text) {
+      return text
+        .split(/\r?\n/)
+        .map((line) => line.trim())
+        .filter(Boolean)
+        .filter((line) => !line.toLowerCase().startsWith("signal_id"))
+        .map((line) => line.split(",").map((value) => value.trim()))
+        .map(([signalId, agencyId, latitude, longitude]) => {
+          const lat = Number(latitude);
+          const lon = Number(longitude);
+          if (!signalId || !agencyId || Number.isNaN(lat) || Number.isNaN(lon)) {
+            return null;
+          }
+          const key = `${signalId}-${agencyId}`;
+          return {
+            key,
+            signalId,
+            agencyId,
+            latitude: lat.toFixed(6),
+            longitude: lon.toFixed(6),
+            displayName: `Signal ${signalId} (${agencyId})`,
+          };
+        })
+        .filter(Boolean);
+    },
+    buildMapUrl(latitude, longitude) {
+      const lat = Number(latitude);
+      const lon = Number(longitude);
+      if (Number.isNaN(lat) || Number.isNaN(lon)) {
+        return "";
+      }
+      const delta = 0.002;
+      const minLon = (lon - delta).toFixed(6);
+      const minLat = (lat - delta).toFixed(6);
+      const maxLon = (lon + delta).toFixed(6);
+      const maxLat = (lat + delta).toFixed(6);
+      return `https://www.openstreetmap.org/export/embed.html?bbox=${minLon}%2C${minLat}%2C${maxLon}%2C${maxLat}&layer=mapnik&marker=${lat}%2C${lon}`;
+    },
+    initializeOverrides() {
+      const updated = {};
+      this.signalRows.forEach((signal) => {
+        updated[signal.key] =
+          this.frequencyOverrides[signal.key] ?? this.defaultFrequency;
+      });
+      this.frequencyOverrides = updated;
+      this.rebuildSchedule();
+    },
+    getFrequencyForSignal(signalKey) {
+      return this.frequencyOverrides[signalKey] ?? this.defaultFrequency;
+    },
+    rebuildSchedule() {
+      const techCount = Math.max(1, Number(this.technicianCount) || 1);
+      const signals = this.signalRows;
+      if (signals.length === 0) {
+        this.scheduleRows = [];
+        return;
+      }
+
+      const visits = [];
+      signals.forEach((signal) => {
+        const frequency = this.getFrequencyForSignal(signal.key);
+        const monthsToVisit = this.months.filter((_, index) => {
+          return index % frequency === 0;
+        });
+        monthsToVisit.forEach((month) => {
+          visits.push({ month, signal: signal.displayName });
+        });
+      });
+
+      const technicians = Array.from({ length: techCount }, (_, index) => ({
+        name: `Technician ${index + 1}`,
+        assignments: Object.fromEntries(this.months.map((month) => [month, []])),
+      }));
+
+      visits.forEach((visit, index) => {
+        const techIndex = index % techCount;
+        technicians[techIndex].assignments[visit.month].push(visit.signal);
+      });
+
+      this.scheduleRows = technicians;
+    },
+  },
+};
+</script>
+
+<style scoped>
+.tool-container {
+  padding: 24px 16px 48px;
+}
+
+.tool-card {
+  margin-bottom: 24px;
+}
+
+.tool-intro {
+  margin-bottom: 16px;
+  line-height: 1.6;
+}
+
+.tool-intro a {
+  color: inherit;
+  font-weight: 600;
+}
+
+.input-label {
+  font-weight: 600;
+  display: block;
+  margin-bottom: 8px;
+}
+
+.settings-card {
+  background: rgba(0, 150, 136, 0.06);
+}
+
+.section-title {
+  font-weight: 600;
+}
+
+.cabinet-table {
+  width: 100%;
+}
+
+.cabinet-table th,
+.cabinet-table td {
+  vertical-align: top;
+  padding: 8px 12px;
+}
+
+.signal-id {
+  font-weight: 600;
+}
+
+.frequency-cell {
+  min-width: 180px;
+}
+
+.map-box {
+  width: 160px;
+  height: 120px;
+  border-radius: 8px;
+  overflow: hidden;
+  border: 1px solid rgba(0, 0, 0, 0.12);
+}
+
+.map-box iframe {
+  width: 100%;
+  height: 100%;
+  border: 0;
+}
+
+.schedule-table {
+  width: 100%;
+  overflow-x: auto;
+}
+
+.tech-name {
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.assignment-list {
+  padding-left: 16px;
+  margin: 0;
+}
+
+.muted-text {
+  color: rgba(0, 0, 0, 0.6);
+}
+</style>


### PR DESCRIPTION
### Motivation
- Make the scheduler accept a compact GTSS CSV with `signal_id,agency_id,latitude,longitude` so lists with coordinates can be pasted directly. 
- Surface a link to `gtss.dev` in the tool intro so users know the source format. 
- Improve layout and density so the tool remains usable with dozens of signals by listing cabinet frequency on one row per signal and adding a small map preview for each signal.

### Description
- Add a new view `src/views/TrafficSignalCabinetPMScheduler.vue` that uses a CSV-style default sample (`signal_id,agency_id,latitude,longitude`) and parses signal ID, agency, latitude and longitude via `parseSignals`.
- Implement per-signal frequency overrides and compact row-based cabinet frequency UI with a per-row `v-select` dropdown and an embedded small map (`iframe`) produced by `buildMapUrl`.
- Register the route in `src/router/index.js` (`/cabinet-pm-scheduler`) and add navigation entries in `src/components/Header.vue` and a home tile in `src/views/Home.vue` to expose the tool in the app UI.
- Add SEO metadata for the page in `src/seo/routes.js` and adjust schedule generation to use the parsed per-signal display labels.

### Testing
- Started the dev server with `npm run dev -- --host 0.0.0.0 --port 5173` and observed Vite report `ready` (local and network URLs printed). (succeeded)
- Ran a Playwright smoke script that navigated to `/cabinet-pm-scheduler` and produced a screenshot artifact; the first attempt returned `ERR_EMPTY_RESPONSE` but a retry succeeded and saved `artifacts/cabinet-pm-scheduler.png`. (succeeded after retry)
- No unit tests were added for this UI-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d6165edf8832b9ddeef1bf991661f)