### PR TITLE
Add weekly calendar view to PM scheduler and immediate GTSS input emission

### DIFF
--- a/src/components/foundational/InputBox.vue
+++ b/src/components/foundational/InputBox.vue
@@ -24,6 +24,7 @@
     type="text"
     rows="10"
     v-model="inputData"
+    @input="emitInput"
     @blur="emitInput"
     @focus="clearText"
     class="input-box"


### PR DESCRIPTION
### Motivation
- Provide a weekly calendar view below the existing tables so a technician-level week-by-week list of cabinets is visible.  
- Add a technician selector (Technician 1, 2, ...) to filter the weekly calendar.  
- Ensure edits to the GTSS signal input update the schedule immediately so rebuilding/typing reflects in the tables.

### Description
- Added a `Weekly Cabinet Calendar` card in `src/views/TrafficSignalCabinetPMScheduler.vue` that renders week rows and cabinet assignments for the selected technician.  
- Implemented `selectedTechnician` state, `technicianOptions` and `weeklyCalendar` computed properties, and a `scheduleRows` watcher to keep the technician selector in sync with rebuilt assignments.  
- Kept the existing monthly schedule logic and bucketed monthly assignments into four weeks per month for the calendar view.  
- Emitted input changes on every keystroke by adding `@input="emitInput"` to the textarea in `src/components/foundational/InputBox.vue` so `signalsInput` updates immediately.

### Testing
- Attempted to run the dev server with `npm run dev` to load the page, but the Vite dev server encountered `vite-plugin-favicon` compatibility issues and could not serve successfully. (failed)  
- Attempted an automated Playwright script to capture a screenshot of `/cabinet-pm-scheduler`, but the page navigation failed with `net::ERR_EMPTY_RESPONSE` because the dev server was not reachable. (failed)  
- No unit or end-to-end tests were available or executed for these frontend-only changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d85e50c40832bab9a28b326c9e840)