### PR TITLE
Clarify phase bubble plot red-runner seconds

### DIFF
--- a/src/views/PhaseBubblePlot.vue
+++ b/src/views/PhaseBubblePlot.vue
@@ -67,7 +67,11 @@ Det 3\t0
       <h2>Split Failure Bubble Plot</h2>
       <p class="muted">
         Use the split history input to size bubbles by average split served and
-        compare split failures to red-light runner exposure.
+        compare split failures to red-light runner exposure. The Y-axis sums
+        elapsed seconds from yellow start for each red-light runner event; time
+        during all-red continues incrementing beyond yellow. If you prefer an
+        average or count instead of a sum, adjust the aggregation logic and
+        update the labels and tooltip text accordingly.
       </p>
       <ProcessSplitHistory
         @phaseSplitAggregates="storePhaseAggregates"
@@ -170,7 +174,9 @@ export default {
                 return [
                   `Phase: ${phase}`,
                   `Split failures: ${raw.x ?? 0}`,
-                  `Red-runner seconds: ${raw.y ?? 0}`,
+                  `Red-runner seconds since yellow start (summed; includes all-red): ${
+                    raw.y ?? 0
+                  }`,
                   `Avg split served: ${raw.avgSplitServed ?? "—"}`,
                 ];
               },
@@ -188,7 +194,7 @@ export default {
           y: {
             title: {
               display: true,
-              text: "Red-light runner seconds since yellow start (summed)",
+              text: "Red-light runner seconds since yellow start (summed; includes all-red)",
             },
             beginAtZero: true,
           },


### PR DESCRIPTION
### Motivation
- Make the Phase Bubble Plot documentation and UI explicit about how the Y-axis is computed: the chart sums elapsed seconds from yellow start for each red-light runner event and continues incrementing during all-red, and provide guidance to change aggregation if averaging/counting is preferred.

### Description
- Update `src/views/PhaseBubblePlot.vue` to add explanatory text in the Split Failure Bubble Plot section and to change the tooltip and Y-axis title to `Red-runner seconds since yellow start (summed; includes all-red)` so the displayed labels explicitly match the aggregation rule.

### Testing
- Launched the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` and used a Playwright script to load `/phase-bubble-plot` and capture a screenshot; the page rendered and a screenshot artifact was produced (dev server logged favicon plugin warnings).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6980374ebf74832bad5640649d0e1bf7)