### PR TITLE
Reposition mapping input and hide detector scatter on Phase Bubble Plot

### DIFF
--- a/src/components/foundational/PlotDetectionTimeSeries.vue
+++ b/src/components/foundational/PlotDetectionTimeSeries.vue
@@ -26,14 +26,16 @@
       </v-expansion-panel-text>
     </v-expansion-panel>
   </v-expansion-panels>
-  <br />
-  <v-btn @click="resetZoom">Reset Zoom</v-btn>
-  <br />
-  <Scatter
-    :data="chartData"
-    :options="chartOptions"
-    ref="scatterChart"
-  ></Scatter>
+  <template v-if="showChart">
+    <br />
+    <v-btn @click="resetZoom">Reset Zoom</v-btn>
+    <br />
+    <Scatter
+      :data="chartData"
+      :options="chartOptions"
+      ref="scatterChart"
+    ></Scatter>
+  </template>
 </template>
 
 <script>
@@ -67,6 +69,10 @@ export default {
     plotData: {
       type: Array,
       required: true,
+    },
+    showChart: {
+      type: Boolean,
+      default: true,
     },
     phaseData: {
       type: Array,

--- a/src/views/PhaseBubblePlot.vue
+++ b/src/views/PhaseBubblePlot.vue
@@ -7,62 +7,38 @@
       <v-expansion-panels v-model="panel" multiple>
         <v-expansion-panel title="About: Phase Bubble Plot" value="about">
           <v-expansion-panel-text>
-            This tool combines detector-to-phase mappings with high-resolution
-            controller events to visualize detector activity aligned to phase
-            service. Use the mapping box to assign detector channels to phases,
-            then plot the detection events against the phase timeline.
+            This tool combines detector-to-phase mappings with split history
+            input so split failure and red-light running metrics can be
+            summarized by phase. Use the mapping box to assign detector
+            channels to phases before running the split failure bubble plot.
           </v-expansion-panel-text>
         </v-expansion-panel>
 
         <v-expansion-panel title="What You Need" value="requirements">
           <v-expansion-panel-text>
             <ul>
-              <li>High-resolution CSV data (timestamp, event code, parameter)</li>
               <li>Detector-to-phase mapping table (detector channel, phase)</li>
+              <li>Split history data for split failures and red-light running</li>
             </ul>
           </v-expansion-panel-text>
         </v-expansion-panel>
 
         <v-expansion-panel title="Example: Using This Tool" value="example">
           <v-expansion-panel-text>
-            Paste high resolution controller data as CSV lines in the format:
-            <pre>
-16764339605, 82, 7
-16764339625, 81, 7
-16764339705, 90, 12
-            </pre>
-            Then paste detector mappings like:
+            Paste detector mappings like:
             <pre>
 Det 1\t6
 Det 2\t2
 Det 3\t0
             </pre>
-            Click <b>Process Bubble Plot</b> to render the visualization.
+            Then load split history data and click <b>Process</b> to review the
+            split failure bubble plot below.
           </v-expansion-panel-text>
         </v-expansion-panel>
       </v-expansion-panels>
     </div>
 
     <br />
-    <ProcessDetectionEvents
-      ref="processDetectionEvents"
-      @detectionEvents="storeDetectionEvents"
-      @phaseEvents="storePhaseEvents"
-      @coordPatternEvents="storeCoordPatternEvents"
-      @coordCycleStateEvents="storeCoordCycleStateEvents"
-    ></ProcessDetectionEvents>
-    <div>
-      <v-btn @click="processDetection" color="primary">
-        Process Bubble Plot
-      </v-btn>
-    </div>
-    <PlotDetectionTimeSeries
-      :plotData="detectionEvents"
-      :phaseData="phaseEvents"
-      :coordPatternData="coordPatternEvents"
-      :coordCycleStateData="coordCycleStateEvents"
-    ></PlotDetectionTimeSeries>
-
     <section class="left-justify-text mt-6">
       <h2>Split Failure Bubble Plot</h2>
       <p class="muted">
@@ -73,9 +49,16 @@ Det 3\t0
         average or count instead of a sum, adjust the aggregation logic and
         update the labels and tooltip text accordingly.
       </p>
-      <ProcessSplitHistory
-        @phaseSplitAggregates="storePhaseAggregates"
-      ></ProcessSplitHistory>
+      <v-row>
+        <v-col cols="12" md="7">
+          <ProcessSplitHistory
+            @phaseSplitAggregates="storePhaseAggregates"
+          ></ProcessSplitHistory>
+        </v-col>
+        <v-col cols="12" md="5">
+          <PlotDetectionTimeSeries :plotData="[]" :showChart="false" />
+        </v-col>
+      </v-row>
       <div v-if="phaseAggregates.length" class="bubble-chart">
         <Bubble :data="bubbleChartData" :options="bubbleChartOptions" />
       </div>
@@ -92,7 +75,6 @@ import {
   Tooltip,
   Legend,
 } from "chart.js";
-import ProcessDetectionEvents from "../components/ProcessDetectionEvents.vue";
 import ProcessSplitHistory from "../components/ProcessSplitHistory.vue";
 import PlotDetectionTimeSeries from "../components/foundational/PlotDetectionTimeSeries.vue";
 
@@ -102,17 +84,12 @@ export default {
   name: "PhaseBubblePlot",
   components: {
     Bubble,
-    ProcessDetectionEvents,
     ProcessSplitHistory,
     PlotDetectionTimeSeries,
   },
   data() {
     return {
       panel: [],
-      detectionEvents: [],
-      phaseEvents: [],
-      coordPatternEvents: [],
-      coordCycleStateEvents: [],
       phaseAggregates: [],
     };
   },
@@ -203,21 +180,6 @@ export default {
     },
   },
   methods: {
-    processDetection() {
-      this.$refs.processDetectionEvents?.processDetectionEvents?.();
-    },
-    storeDetectionEvents(events) {
-      this.detectionEvents = events;
-    },
-    storePhaseEvents(events) {
-      this.phaseEvents = events;
-    },
-    storeCoordPatternEvents(events) {
-      this.coordPatternEvents = events;
-    },
-    storeCoordCycleStateEvents(events) {
-      this.coordCycleStateEvents = events;
-    },
     storePhaseAggregates(data) {
       this.phaseAggregates = data;
     },


### PR DESCRIPTION
### Motivation
- Simplify the Phase Bubble Plot workflow by removing the high-resolution controller input and its process button while preserving the detector-to-phase mapping UI for split-failure analysis.
- Place the detector-to-phase alignment next to the split history input so users can assign mappings while preparing split history data.

### Description
- Added a `showChart` prop to `src/components/foundational/PlotDetectionTimeSeries.vue` (default `true`) and wrapped the reset button and `Scatter` chart in `v-if="showChart"` so the scatter can be hidden without removing the mapping UI.
- Updated `src/views/PhaseBubblePlot.vue` to remove `ProcessDetectionEvents`, the top high-resolution input, and the `Process Bubble Plot` button, and removed associated state and methods.
- Repositioned the detector-to-phase mapping panel beside the `ProcessSplitHistory` input using a `v-row`/`v-col` layout and embedded `PlotDetectionTimeSeries` with `:plotData="[]"` and `:showChart="false"` to keep the mapping editor visible but hide the detector scatter.
- Revised guidance text in the About/Example panels to reflect the split-history-focused workflow and removed references to high-resolution CSV input.

### Testing
- Started the development server with `npm run dev` and confirmed Vite reported the server as ready at `http://localhost:4173/` (success). 
- Ran a Playwright script to load `/phase-bubble-plot` and capture a screenshot; the script produced an artifact and completed successfully after an initial retry when the server was still coming up. 
- No unit tests were added for these UI-only changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69803ab80840832b82555977d9cf2c6b)