### PR TITLE
Add split failure event details table to Phase Bubble Plot

### DIFF
--- a/src/components/ProcessSplitHistory.vue
+++ b/src/components/ProcessSplitHistory.vue
@@ -108,8 +108,13 @@ export default {
         this.hdDataObj,
         patternChanges
       );
+      const splitFailureEvents = this.collectSplitFailureEvents(
+        this.hdDataObj,
+        phaseAggregates.map((entry) => entry.phase)
+      );
       this.$emit("phaseSplitAggregates", phaseAggregates);
       this.$emit("phaseSplitPatternAggregates", patternAggregates);
+      this.$emit("splitFailureEvents", splitFailureEvents);
       //emit here not necessary because buildCycleItem emit's the phase data
       console.log(allHDData);
       //this.rowData = this.fillInEndTime(this.rowData);


### PR DESCRIPTION
### Motivation
- Provide a detailed, per-phase list of split failure events alongside the existing split-failure bubble visualization so users can inspect timestamps and context for each failure.

### Description
- Added `collectSplitFailureEventsForPhase` and `collectSplitFailureEvents` to `src/mixins/processPhaseSplits.js` to gather per-phase split failure records including detector-on, yellow-start, and red-clear timestamps.
- Emitted the collected split failure events from `ProcessSplitHistory` by calling `collectSplitFailureEvents` and emitting `splitFailureEvents` in `src/components/ProcessSplitHistory.vue`.
- Subscribed to `splitFailureEvents` in the Phase Bubble Plot view and rendered a compact table of failure details with formatted timestamps and stable sorting in `src/views/PhaseBubblePlot.vue`.
- Added helper `formatTimestamp` and `splitFailureRows` computed mapping to present human-readable timestamp fields and minor styling for the new table.

### Testing
- Started the dev server with `npm run dev` (Vite) and confirmed the server reported ready (local and network URLs), which succeeded.
- Automated UI verification using Playwright to load `/phase-bubble-plot` and capture a screenshot succeeded and produced an artifact of the rendered screen.
- No unit tests or CI test-suite were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69804616aa7c832bad76a23320904599)