### PR TITLE
Allow detector-first assignment inputs for split failures

### DIFF
--- a/src/views/SplitFailureChecker.vue
+++ b/src/views/SplitFailureChecker.vue
@@ -23,9 +23,9 @@
                 <code>1/6/2024 15:00:03.3, 7, 4</code>
               </li>
               <li>
-                Stop bar detector assignments as <b>phase, detector channel</b>.
-                Labels like <code>Det 1</code> are accepted. Example:
-                <code>4, 12</code>
+                Stop bar detector assignments as <b>phase, detector channel</b> or
+                <b>detector, phase</b>. Labels like <code>Det 1</code> are
+                accepted. Example: <code>4, 12</code> or <code>Det 12, 4</code>
               </li>
             </ul>
           </v-expansion-panel-text>
@@ -125,7 +125,7 @@ export default {
       processed: false,
       defaultText: "Paste high-resolution data: timestamp, event code, parameter",
       assignmentPlaceholder:
-        "Paste stop bar detector assignments: phase, detector channel. Labels like 'Det 1' are supported.",
+        "Paste stop bar detector assignments: phase, detector channel (or detector, phase). Labels like 'Det 1' are supported.",
     };
   },
   computed: {
@@ -201,8 +201,11 @@ export default {
           if (parts.length < 2) {
             return;
           }
-          const phase = this.parseNumberFromText(parts[0]);
-          const detector = this.parseNumberFromText(parts[1]);
+          const detectorFirst = /det/i.test(parts[0]);
+          const phase = this.parseNumberFromText(detectorFirst ? parts[1] : parts[0]);
+          const detector = this.parseNumberFromText(
+            detectorFirst ? parts[0] : parts[1]
+          );
           if (Number.isNaN(phase) || Number.isNaN(detector)) {
             return;
           }


### PR DESCRIPTION
### Motivation
- Support detector-to-phase assignment lines in addition to phase-to-detector so inputs like `Det 17\t1` or `Det 12, 4` are accepted for the split failure checker.

### Description
- Update the UI input guidance to mention that detector-first (`detector, phase`) lines are supported and adjust the placeholder text accordingly.
- Extend `parseAssignments()` to detect detector-labeled inputs using `/det/i` and swap extraction so the numeric phase and detector are parsed in either order.
- Preserve existing normalization to a `Map<phase, number[]>` of sorted detector channels and keep downstream split-failure logic unchanged.

### Testing
- Started the dev server with `npm run dev` and observed Vite report as ready, which succeeded. 
- Ran an automated Playwright script to load `/#/split-failure-checker` and capture a screenshot, which succeeded and produced the page artifact.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69818b3d8e98832ba41f73c54576dd33)