### PR TITLE
Use split failure algorithm for phase bubble plot x-axis

### DIFF
--- a/src/views/PhaseBubblePlot.vue
+++ b/src/views/PhaseBubblePlot.vue
@@ -43,11 +43,12 @@ Det 3\t0
       <h2>Split Failure Bubble Plot</h2>
       <p class="muted">
         Use the split history input to size bubbles by average split served and
-        compare split failures to red-light runner exposure. The Y-axis sums
-        elapsed seconds from yellow start for each red-light runner event; time
-        during all-red continues incrementing beyond yellow. If you prefer an
-        average or count instead of a sum, adjust the aggregation logic and
-        update the labels and tooltip text accordingly.
+        compare split failures (split failure algorithm) to red-light runner
+        exposure. The Y-axis sums elapsed seconds from yellow start for each
+        red-light runner event; time during all-red continues incrementing
+        beyond yellow. If you prefer an average or count instead of a sum,
+        adjust the aggregation logic and update the labels and tooltip text
+        accordingly.
       </p>
       <v-row>
         <v-col cols="12" md="7">
@@ -191,7 +192,7 @@ export default {
             label: `Phase ${row.phase}`,
             data: [
               {
-                x: Number(row.splitFailures) || 0,
+                x: Number(row.splitFailuresAlgorithm ?? row.splitFailures) || 0,
                 y: Number(row.redRunnerSeconds) || 0,
                 r: radius,
                 phase: row.phase,
@@ -233,7 +234,7 @@ export default {
                 const phase = raw.phase ?? context.dataset.label;
                 return [
                   `Phase: ${phase}`,
-                  `Split failures: ${raw.x ?? 0}`,
+                  `Split failures (algorithm): ${raw.x ?? 0}`,
                   `Red-runner seconds since yellow start (summed; includes all-red): ${
                     raw.y ?? 0
                   }`,
@@ -247,7 +248,7 @@ export default {
           x: {
             title: {
               display: true,
-              text: "Split Failures",
+              text: "Split Failures (Algorithm)",
             },
             beginAtZero: true,
           },


### PR DESCRIPTION
### Motivation

- Provide a more accurate x-axis for the Phase Bubble Plot by using the split-failure algorithm count instead of (or alongside) the previous/naive metric.

### Description

- Added `countSplitFailuresAlgorithmForPhase` to `src/mixins/processPhaseSplits.js` to compute split failures using the split-failure algorithm and track phase end reasons and detector state.
- Extended phase aggregate objects with a new `splitFailuresAlgorithm` field and populate it during `aggregatePhaseSplitMetrics` in `src/mixins/processPhaseSplits.js`.
- Updated `src/views/PhaseBubblePlot.vue` to use `splitFailuresAlgorithm` for the dataset x-value (falling back to `splitFailures` if the algorithm value is absent) and refreshed the plot copy, x-axis label, and tooltip to indicate the algorithm-based metric.
- Kept existing split failure event collection and table output intact while surfacing the algorithm count on the visualization.

### Testing

- Launched the dev server and used a headless browser (Playwright) to open `/phase-bubble-plot` and capture a full-page screenshot, which completed successfully and produced an artifact image of the updated plot.
- The initial navigation attempt returned `ERR_EMPTY_RESPONSE` but a subsequent run succeeded and produced the screenshot; no unit tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698190f0f98c832ba1ed8727f883c317)