### PR TITLE
Set light-mode background for High-Resolution Data Explainer post

### DIFF
--- a/src/views/HighResDataExplainerPost.vue
+++ b/src/views/HighResDataExplainerPost.vue
@@ -129,6 +129,7 @@ export default {
   padding: 32px 20px 48px;
   font-family: "Georgia", "Times New Roman", serif;
   color: #111;
+  background: #fff;
 }
 
 .article-header {


### PR DESCRIPTION
### Motivation
- Prevent the High-Resolution Data Explainer blog post from appearing all black in non-dark mode by forcing a light background for the article container.

### Description
- Add `background: #fff;` to the `.blog-article` selector in `src/views/HighResDataExplainerPost.vue` to ensure a white background in light mode.

### Testing
- Started the dev server with `npm run dev`, and Vite reported the server ready at `http://localhost:4173`.
- Ran a Playwright script to navigate to `/blog/high-resolution-data-explainer` and capture a screenshot saved to `artifacts/high-res-data-explainer.png`, which succeeded after an initial `ERR_EMPTY_RESPONSE` navigation error.
- Noted an unrelated Vite compile error (`Element is missing end tag`) reported for `src/views/Blog.vue` during dev server startup, but the target page was still rendered for the screenshot.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698819f2bb50832bb89f10fd4ea340cc)