### PR TITLE
Fix blog post list

### DIFF
--- a/src/views/Blog.vue
+++ b/src/views/Blog.vue
@@ -14,7 +14,12 @@
         </p>
       </v-card-text>
     </v-card>
-    <v-card class="blog-card blog-card--link" variant="outlined" to="/blog/offsets-are-the-point" link>
+    <v-card
+      class="blog-card blog-card--link"
+      variant="outlined"
+      to="/blog/offsets-are-the-point"
+      link
+    >
       <v-card-title>Offsets Are the Point</v-card-title>
       <v-card-subtitle>
         Why Cycle Length, Splits, and TOD Schedules Exist Only to Serve the Green Wave
@@ -78,7 +83,21 @@
           Learn what counts as a split, how green/yellow/all-red roll into each
           cycle, and how to filter the report to the timing patterns that
           matter.
-
+        </p>
+      </v-card-text>
+      <v-card-actions>
+        <v-btn
+          color="primary"
+          variant="text"
+          to="/blog/high-resolution-split-history"
+        >
+          Read the article
+        </v-btn>
+      </v-card-actions>
+    </v-card>
+    <v-card
+      class="blog-card blog-card--link"
+      variant="outlined"
       to="/blog/timeseries-plot-all-enumerations"
       link
     >
@@ -99,11 +118,15 @@
         <v-btn
           color="primary"
           variant="text"
-          to="/blog/high-resolution-split-history"
-        >
           to="/blog/timeseries-plot-all-enumerations"
         >
-
+          Read the article
+        </v-btn>
+      </v-card-actions>
+    </v-card>
+    <v-card
+      class="blog-card blog-card--link"
+      variant="outlined"
       to="/blog/gpx-mapper-guide"
       link
     >


### PR DESCRIPTION
### Motivation

- The blog landing page contained broken/misaligned markup and was missing several posts that exist in the app router, resulting in an incomplete post list.

### Description

- Repair and reformat `src/views/Blog.vue` to fix malformed template markup and restore proper card layout for the blog landing page.
- Add missing post cards and align links with the available routes including ` /blog/high-resolution-split-history`, `/blog/timeseries-plot-all-enumerations`, and `/blog/gpx-mapper-guide`.
- Standardize card action buttons so each card shows a consistent "Read the article" CTA and correct `to` targets.

### Testing

- Launched the dev server with `npm run dev` and verified the `/blog` page loaded successfully in a headless browser.
- Captured a screenshot of the rendered `/blog` route with Playwright to confirm the full post list renders as expected, and the capture completed successfully.
- Changes were committed after verification to ensure the updated `src/views/Blog.vue` is tracked.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69881fe354ac832bae1a4d5a610f5c7e)