### PR TITLE
Fix manifest paths for subpath hosting

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
   />
 
   <link rel="icon" href="/favicon.ico">
-  <link rel="manifest" href="/site.webmanifest">
+  <link rel="manifest" href="site.webmanifest">
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
    <!-- Font Awesome -->
    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.3/css/all.min.css">

--- a/public/site.webmanifest
+++ b/public/site.webmanifest
@@ -1,11 +1,11 @@
 {
   "name": "Traffic Signal Kit",
   "short_name": "TrafficSignalKit",
-  "start_url": "/",
+  "start_url": ".",
   "display": "standalone",
   "background_color": "#ffffff",
   "theme_color": "#009688",
   "icons": [
-    { "src": "/favicon.ico", "sizes": "any", "type": "image/x-icon" }
+    { "src": "favicon.ico", "sizes": "any", "type": "image/x-icon" }
   ]
 }


### PR DESCRIPTION
### Motivation
- Fix incorrect root-based manifest and icon paths so the browser doesn't fetch HTML at the site root and report a manifest parse error when the app is hosted on a subpath.

### Description
- Updated the manifest link in `index.html` to a relative path and changed `public/site.webmanifest` `start_url` to `.` and icon `src` to `favicon.ico` to support subpath hosting.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988227b4314832b9b24b8a8614e800f)