### PR TITLE
Improve dark mode styling for GPX Mapper guide

### DIFF
--- a/src/views/GPXMapperKnowledgeHubPost.vue
+++ b/src/views/GPXMapperKnowledgeHubPost.vue
@@ -288,4 +288,41 @@ export default {
 .article-actions {
   margin-top: 16px;
 }
+
+@media (prefers-color-scheme: dark) {
+  .blog-article {
+    color: #f5f5f5;
+    background: #0f0f0f;
+  }
+
+  .article-header {
+    border-top-color: #f5f5f5;
+    border-bottom-color: #f5f5f5;
+  }
+
+  .article-subtitle {
+    color: rgba(255, 255, 255, 0.7);
+  }
+
+  .article-meta {
+    color: rgba(255, 255, 255, 0.6);
+  }
+
+  .article-callout {
+    border-left-color: #f5f5f5;
+  }
+
+  .article-body {
+    column-rule-color: rgba(255, 255, 255, 0.2);
+  }
+
+  .coordinate-table th,
+  .coordinate-table td {
+    border-color: rgba(255, 255, 255, 0.2);
+  }
+
+  .coordinate-table th {
+    background: rgba(255, 255, 255, 0.08);
+  }
+}
 </style>


### PR DESCRIPTION
### Motivation
- Improve readability of the GPX Mapper Knowledge Hub article when the system/browser prefers dark mode by ensuring text, borders, and table backgrounds are legible.

### Description
- Add a `@media (prefers-color-scheme: dark)` block to `src/views/GPXMapperKnowledgeHubPost.vue` that overrides article text and background colors for dark mode.
- Adjust header and callout border colors and subtitle/meta text for dark mode.
- Tweak `.coordinate-table` header/background and cell border colors so table content remains readable in dark mode.

### Testing
- Started the local dev server with `npm run dev` and confirmed Vite reported the app as ready at `http://localhost:4173/` (server start succeeded).
- Captured a dark-mode page rendering using a Playwright script that opened the guide page and saved a screenshot to `artifacts/gpx-mapper-dark.png`, and the final Playwright run succeeded.
- Observed Vite plugin warnings in serve mode but the dark-mode visual verification completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69882a278c90832bb759be1081ff0a7b)