### PR TITLE
Plot all phases simultaneously in Phase Bubble Scatter

### DIFF
--- a/src/utils/phaseBubbleScatter.js
+++ b/src/utils/phaseBubbleScatter.js
@@ -152,6 +152,7 @@ export function buildPhaseBubblePoints({ events, selectedPhase, assignedDetector
     const fillFactor = maxOff > 0 ? row.offCount / maxOff : 0;
     const alpha = maxOff > 0 ? Math.max(minAlpha, Math.min(maxAlpha, maxAlpha - fillFactor * (maxAlpha - minAlpha))) : maxAlpha;
     return {
+      phase: selectedPhase,
       cycle_index: row.cycleIndex,
       service_start_ts: row.startTs,
       service_start_iso: new Date(row.startTs).toISOString(),


### PR DESCRIPTION
### Motivation

- The Phase Bubble Scatter tool should show all detected phases at once instead of forcing the user to pick a single phase from a dropdown so analysts can compare phase behavior side-by-side.

### Description

- Removed the single-phase dropdown and changed the UI to render one chart dataset per detected phase with a distinct hue for each phase in `src/views/PhaseBubbleScatter.vue`.
- Added `phase` to generated point objects and updated table, tooltip, CSV export, PNG/SVG export logic so each row and bubble is annotated and grouped by phase in `src/utils/phaseBubbleScatter.js` and `src/views/PhaseBubbleScatter.vue`.
- Reworked the worker to compute points for all detected service phases in one run (and sort/merge the results) so the front-end receives a single combined point list in `src/workers/phaseBubbleScatterWorker.js`.
- Preserved existing bubble sizing/alpha semantics while assigning per-phase hue and using per-phase split arrays for size capping.

### Testing

- Ran `npm test` and all tests passed (4/4).
- Built the production bundle with `npm run build` which completed successfully.
- Launched a preview and verified the app responded with HTTP 200 using `curl -I`, and captured a Playwright screenshot of the updated page which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699dbb555ba0832ba2432ea60ea8dcd7)