### PR TITLE
Fix PhaseBubbleScatter bubble point parsing

### DIFF
--- a/src/views/PhaseBubbleScatter.vue
+++ b/src/views/PhaseBubbleScatter.vue
@@ -113,7 +113,6 @@ export default {
       return {
         responsive: true,
         animation: false,
-        parsing: false,
         scales: {
           x: { title: { display: true, text: 'Cycle (unique per cycle, phase not repeated)' } },
           y: { title: { display: true, text: 'Time since the last time the phase was ON (s)' } },


### PR DESCRIPTION
### Motivation
- Allow Chart.js to parse bubble point objects normally so `x`, `y`, and `r` are consumed as native bubble fields and bubble radii reflect `split_s` values.

### Description
- Removed `parsing: false` from `chartOptions` in `src/views/PhaseBubbleScatter.vue` so datasets can provide points as `{ x, y, r, meta }` and `meta` remains available for tooltip callbacks.

### Testing
- Ran unit tests with `npm test` and all tests passed.
- Executed a headless browser automation that injected sample points into the `/phase-bubble-scatter` view and asserted that a larger `split_s` produced a larger rendered radius (assertion succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f6ad05254832ba41b01636e4c0ed3)