### PR TITLE
Phase Bubble Scatter: single sizing dropdown, detector-delay y-axis, and unified download

### DIFF
--- a/src/workers/phaseBubbleScatterWorker.js
+++ b/src/workers/phaseBubbleScatterWorker.js
@@ -9,7 +9,7 @@ self.onmessage = (event) => {
     const serviceCodes = new Set([1, 7, 8, 9, 10, 11, 12]);
     const phases = [...new Set(events.filter((evt) => serviceCodes.has(evt.code) && evt.param >= 1 && evt.param <= 16).map((evt) => evt.param))].sort((a, b) => a - b);
     const points = phases.flatMap((phase) => {
-      const assignedDetectors = payload.useAllDetectorsForPhase ? (assignments.get(phase) || []) : (assignments.get(phase) || []).slice(0, 1);
+      const assignedDetectors = assignments.get(phase) || [];
       return buildPhaseBubblePoints({
         events,
         selectedPhase: phase,


### PR DESCRIPTION
### Motivation

- Simplify and consolidate the Phase Bubble Scatter controls so bubble sizing, y-axis metric, and downloads fit in the UI and are easier to use.
- Provide an option to view detector delay-to-green as the y-axis (delay from first detector ON after prior service end to service-start) to enable delay-based analysis in addition to OFF transition counts.

### Description

- Replaced the two-step bubble sizing controls with a single dropdown offering `Linear`, `Scaled - Sqrt`, and `Scaled - Log` and wired it into the bubble radius computation (`src/views/PhaseBubbleScatter.vue`, `src/utils/phaseBubbleScatter.js`).
- Added a y-axis toggle that switches between detector OFF transition count and detector delay-to-green, and updated chart data/tooltip/table to surface `detector_delay_s` (`src/views/PhaseBubbleScatter.vue`, `src/utils/phaseBubbleScatter.js`).
- Implemented `computeDetectorDelayToGreen(events, windows, detectors)` to compute the delay metric and propagated `detector_delay_s` into the generated phase points (`src/utils/phaseBubbleScatter.js`).
- Removed the UI toggle for "use all detectors in phase" and updated the worker to always use assigned detectors per phase; consolidated CSV/PNG/SVG buttons into a single `Download` button with a format selector (`src/workers/phaseBubbleScatterWorker.js`, `src/views/PhaseBubbleScatter.vue`).
- Added/updated unit tests to cover the detector-delay computation and its inclusion in output points (`tests/phaseBubbleScatter.test.mjs`).

### Testing

- Ran `npm test` which includes new tests in `tests/phaseBubbleScatter.test.mjs`, and all tests passed.
- Ran `npm run build` and the production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699fb353ff0c832b9d29ae6bfdc76be7)