### PR TITLE
Phase Bubble Scatter: configurable axes, bubble sizing, transparency and new metrics

### DIFF
--- a/src/utils/phaseBubbleScatter.js
+++ b/src/utils/phaseBubbleScatter.js
@@ -183,6 +183,8 @@ export function buildPhaseBubblePoints({ events, selectedPhase, assignedDetector
       time_since_last_on_s: since,
       detector_delay_s: row.detectorDelayS,
       off_count: row.offCount,
+      off_per_split: row.splitS > 0 ? row.offCount / row.splitS : null,
+      delay_per_split: row.splitS > 0 && Number.isFinite(row.detectorDelayS) ? row.detectorDelayS / row.splitS : null,
       assigned_detectors: assignedDetectors,
       alpha,
       fill_factor: fillFactor,


### PR DESCRIPTION
### Motivation
- Make the Phase Bubble Scatter plot more flexible by letting users choose which numeric phase-cycle fields drive X, Y, bubble size, and transparency so different analyses can be explored without code changes. 
- Provide additional per-cycle metrics useful for selection and comparison in the dropdowns and exports. 
- Let users invert how metric values map to transparency so high values can be rendered darker or lighter depending on analysis needs.

### Description
- Added dropdowns in `PhaseBubbleScatter.vue` for selecting `xAxisField`, `yAxisField`, `bubbleSizeField`, and `transparencyField`, and an `invertTransparency` switch to flip high/low → alpha mapping. 
- Implemented `numericFieldOptions` and dynamic labels via `fieldLabel`/`fieldValue`, and computed `pointsWithStyle` to normalize transparency, compute alpha, fill factor and bubble radius per point; chart uses selected fields for coordinates and size. 
- Added two new calculated fields in `buildPhaseBubblePoints` (`src/utils/phaseBubbleScatter.js`): `off_per_split` and `delay_per_split`, surfaced in the table, tooltips, and CSV export. 
- Updated table headers, tooltip content, and CSV export to include the new fields and to export rows using the styled/augmented points (including computed `alpha`, `fill_factor`, and `radius`). 
- Kept previous sizing options and cap behavior; replaced the old Y-axis toggle for detector-delay/offs with the more general field-selection approach.

### Testing
- Ran a production build with `npm run build` which completed successfully. 
- Launched the dev server and verified the application root returned `HTTP/1.1 200 OK` using `curl -I http://127.0.0.1:4173/`. 
- Captured an updated UI screenshot of `/phase-bubble-scatter` using a headless browser script to validate the new controls rendered as expected. 
- No unit tests were added; manual/visual checks described above succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699fee74d4e4832bb47c5051fa6d592e)