### PR TITLE
Add simple starter templates for Block Logic tool

### DIFF
--- a/src/utils/blockLogicSchema.js
+++ b/src/utils/blockLogicSchema.js
@@ -96,6 +96,39 @@ export function validateSchema(schema) {
 export function builtInTemplates() {
   return [
     {
+      name: 'Basic: Detector On',
+      schema: {
+        version: BLOCK_LOGIC_SCHEMA_VERSION,
+        rules: [{
+          ...createRule('Detector 1 Turns On'),
+          if: { type: 'detector', channel: 1, target: 1, mode: 'edgeRising' },
+          actions: [createAction('appendTableRow')],
+        }],
+      },
+    },
+    {
+      name: 'Basic: Phase Green On',
+      schema: {
+        version: BLOCK_LOGIC_SCHEMA_VERSION,
+        rules: [{
+          ...createRule('Phase 2 Green Turns On'),
+          if: { type: 'phase', signal: 'green', phase: 2, target: 1, mode: 'edgeRising' },
+          actions: [createAction('plotPoint')],
+        }],
+      },
+    },
+    {
+      name: 'Basic: Phase Green Off',
+      schema: {
+        version: BLOCK_LOGIC_SCHEMA_VERSION,
+        rules: [{
+          ...createRule('Phase 2 Green Turns Off'),
+          if: { type: 'phase', signal: 'green', phase: 2, target: 0, mode: 'edgeFalling' },
+          actions: [createAction('appendTableRow')],
+        }],
+      },
+    },
+    {
       name: 'Detector Stuck On',
       schema: {
         version: BLOCK_LOGIC_SCHEMA_VERSION,


### PR DESCRIPTION
### Motivation
- Provide very basic built-in examples so users can quickly verify the Block Logic canvas and rule firing with minimal setup, easing onboarding and debugging.

### Description
- Added three new lightweight templates to `builtInTemplates()` in `src/utils/blockLogicSchema.js`: `Basic: Detector On`, `Basic: Phase Green On`, and `Basic: Phase Green Off` that each contain a single IF condition and one action.
- Each template uses existing helpers (`createRule`, `createCondition`-style objects, and `createAction`) and keeps the schema version and format consistent with existing templates.
- Left the more advanced templates (`Detector Stuck On`, `Green Extension Marker`, `Split Failure Proxy`) intact so users still have the original examples.

### Testing
- Ran `npm run build` successfully with the production build completing without errors.
- Launched a preview/dev server and used an automated Playwright script to open `http://127.0.0.1:4173/tools/block-logic` and capture a screenshot showing the template dropdown including the new basic templates.
- Started the dev server manually which worked but produced repeated `vite-plugin-favicon` warnings in serve mode in this environment (non-blocking).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9151d2c14832b97cab8380b68582d)