### PR TITLE
Add time-bucketed phase pressure computation with detector ON/OFF, terminations, and audit tooltips

### DIFF
--- a/src/components/PhasePressureMapTool.vue
+++ b/src/components/PhasePressureMapTool.vue
@@ -26,6 +26,16 @@
         <v-row class="mt-2">
           <v-col cols="12" md="4">
             <v-text-field
+              v-model.number="binSizeMinutes"
+              type="number"
+              min="1"
+              max="60"
+              step="1"
+              label="Bin size (minutes)"
+            />
+          </v-col>
+          <v-col cols="12" md="4">
+            <v-text-field
               v-model.number="minServiceSeconds"
               type="number"
               min="0"
@@ -39,11 +49,14 @@
         </v-row>
 
         <div v-if="errorMessage" class="error-message">{{ errorMessage }}</div>
+        <div v-if="unmappedDetectorEvents > 0" class="help-text mt-1">
+          Ignored {{ unmappedDetectorEvents }} detector events from unmapped channels.
+        </div>
       </v-card-text>
     </v-card>
 
     <v-card v-if="pressureRows.length" variant="outlined">
-      <v-card-title>Phase Pressure by Service Cycle</v-card-title>
+      <v-card-title>Phase Pressure by Time Bin</v-card-title>
       <v-card-text>
         <div class="cycle-legend mb-4">
           <span>Low pressure</span>
@@ -53,7 +66,7 @@
 
         <div class="heat-map-shell">
           <div class="phase-axis" :style="phaseAxisStyle">
-            <div class="axis-header-cell">Cycle</div>
+            <div class="axis-header-cell">Bin</div>
             <div v-for="phase in orderedPhases" :key="`head-${phase}`" class="phase-header">
               Ph {{ phase }}
             </div>
@@ -62,7 +75,7 @@
           <div class="heat-map-scroll-y">
             <div class="heat-map-grid" :style="gridStyle">
               <template v-for="row in pressureRows" :key="`cycle-${row.cycleNumber}`">
-                <div class="cycle-label">Cycle {{ row.cycleNumber }}</div>
+                <div class="cycle-label">Bin {{ row.cycleNumber }}</div>
                 <div
                   v-for="phase in orderedPhases"
                   :key="`cell-${row.cycleNumber}-${phase}`"
@@ -97,12 +110,14 @@ export default {
         "Paste high-resolution CSV data (timestamp, event code, parameter) or switch to file upload.",
       detectorPhaseMapInput: "",
       minServiceSeconds: 1,
+      binSizeMinutes: 5,
       orderedPhases: [],
       pressureRows: [],
       maxPressure: 0,
       errorMessage: "",
       mappingErrors: [],
       channelToPhaseMap: {},
+      unmappedDetectorEvents: 0,
     };
   },
   computed: {
@@ -137,6 +152,30 @@ export default {
           .filter((code) => !Number.isNaN(code)),
       );
     },
+    detectorOffCodes() {
+      return new Set(
+        enumerationObj
+          .filter((item) => item.eventDescriptor.toLowerCase().includes("detector off"))
+          .map((item) => Number(item.eventCode))
+          .filter((code) => !Number.isNaN(code)),
+      );
+    },
+    gapOutCodes() {
+      return new Set(
+        enumerationObj
+          .filter((item) => item.eventDescriptor.toLowerCase().includes("gap out"))
+          .map((item) => Number(item.eventCode))
+          .filter((code) => !Number.isNaN(code)),
+      );
+    },
+    maxOutCodes() {
+      return new Set(
+        enumerationObj
+          .filter((item) => item.eventDescriptor.toLowerCase().includes("max out"))
+          .map((item) => Number(item.eventCode))
+          .filter((code) => !Number.isNaN(code)),
+      );
+    },
     phaseAxisStyle() {
       return {
         gridTemplateColumns: `120px repeat(${this.orderedPhases.length}, minmax(48px, 1fr))`,
@@ -156,6 +195,7 @@ export default {
       this.orderedPhases = [];
       this.maxPressure = 0;
       this.channelToPhaseMap = {};
+      this.unmappedDetectorEvents = 0;
 
       const mappingResult = this.parseDetectorPhaseMap(this.detectorPhaseMapInput);
       this.mappingErrors = mappingResult.errors;
@@ -176,38 +216,17 @@ export default {
         return;
       }
 
+      const binSizeMs = Math.max(1, Number(this.binSizeMinutes) || 1) * 60 * 1000;
+      const bins = this.buildTimeBins(records, binSizeMs);
       const phaseIntervalsByPhase = this.buildPhaseIntervals(records);
-      const detectorOnEventsByPhase = this.buildDetectorOnEventsByPhase(records);
-
-      const perPhaseRows = [];
-      phaseIntervalsByPhase.forEach((intervals, phase) => {
-        const detectorOnEvents = detectorOnEventsByPhase.get(phase) || [];
-        let previousEnd = null;
-
-        intervals.forEach((interval, index) => {
-          const serviceSeconds = Math.max(0, (interval.endMs - interval.startMs) / 1000);
-          const serviceFloor = Math.max(0, Number(this.minServiceSeconds) || 0);
-          const safeServiceSeconds = Math.max(serviceSeconds, serviceFloor);
-
-          const windowStart = previousEnd === null ? Number.NEGATIVE_INFINITY : previousEnd;
-          const demandCount = detectorOnEvents.filter(
-            (timestampMs) => timestampMs > windowStart && timestampMs <= interval.startMs,
-          ).length;
-          const pressure = safeServiceSeconds > 0 ? demandCount / safeServiceSeconds : 0;
-
-          perPhaseRows.push({
-            phase,
-            cycleNumber: index + 1,
-            demandCount,
-            serviceSeconds,
-            pressure,
-            windowStart,
-            startMs: interval.startMs,
-          });
-
-          previousEnd = interval.endMs;
-        });
-      });
+      const detectorMetricsByPhase = this.buildDetectorDemandMetrics(records, bins);
+      const terminationCountsByPhase = this.buildTerminationCounts(records, bins);
+      const perPhaseRows = this.buildRowsByBin(
+        bins,
+        phaseIntervalsByPhase,
+        detectorMetricsByPhase,
+        terminationCountsByPhase,
+      );
 
       if (!perPhaseRows.length) {
         this.errorMessage = "No phase service intervals were detected in the input.";
@@ -230,10 +249,7 @@ export default {
         cycleRow.byPhase[row.phase] = row;
       });
 
-      this.maxPressure = perPhaseRows.reduce(
-        (maxValue, row) => Math.max(maxValue, row.pressure),
-        0,
-      );
+      this.maxPressure = perPhaseRows.reduce((maxValue, row) => Math.max(maxValue, row.pressure), 0);
     },
     parseDetectorPhaseMap(input) {
       const channelToPhaseMap = {};
@@ -325,6 +341,24 @@ export default {
         .filter(Boolean)
         .sort((a, b) => a.timestampMs - b.timestampMs);
     },
+    buildTimeBins(records, binSizeMs) {
+      const startMs = records[0].timestampMs;
+      const endMs = records[records.length - 1].timestampMs;
+      const firstBinStart = Math.floor(startMs / binSizeMs) * binSizeMs;
+      const bins = [];
+
+      for (let binStart = firstBinStart; binStart <= endMs; binStart += binSizeMs) {
+        const binEnd = binStart + binSizeMs;
+        bins.push({
+          startMs: binStart,
+          endMs: binEnd,
+          startTime: new Date(binStart).toLocaleTimeString(),
+          endTime: new Date(binEnd).toLocaleTimeString(),
+        });
+      }
+
+      return bins;
+    },
     buildPhaseIntervals(records) {
       const intervalsByPhase = new Map();
       const openStartByPhase = new Map();
@@ -359,28 +393,180 @@ export default {
       intervalsByPhase.forEach((intervals) => intervals.sort((a, b) => a.startMs - b.startMs));
       return intervalsByPhase;
     },
-    buildDetectorOnEventsByPhase(records) {
-      const eventsByPhase = new Map();
+    buildDetectorDemandMetrics(records, bins) {
+      const metricsByPhase = new Map();
+      const openOnByChannel = new Map();
+
+      const ensurePhaseBin = (phase, binIndex) => {
+        if (!metricsByPhase.has(phase)) {
+          metricsByPhase.set(phase, []);
+        }
+        const phaseBins = metricsByPhase.get(phase);
+        if (!phaseBins[binIndex]) {
+          phaseBins[binIndex] = {
+            activationCount: 0,
+            occupancySeconds: 0,
+          };
+        }
+        return phaseBins[binIndex];
+      };
+
+      const addOccupancySpan = (phase, startMs, endMs) => {
+        if (endMs <= startMs) {
+          return;
+        }
+        bins.forEach((bin, binIndex) => {
+          const overlapMs = Math.max(0, Math.min(endMs, bin.endMs) - Math.max(startMs, bin.startMs));
+          if (overlapMs <= 0) {
+            return;
+          }
+          const binMetrics = ensurePhaseBin(phase, binIndex);
+          binMetrics.occupancySeconds += overlapMs / 1000;
+        });
+      };
 
       records.forEach((record) => {
-        if (!this.detectionOnCodes.has(record.eventCode)) {
-          return;
-        }
-
         const mappedPhase = this.channelToPhaseMap[record.parameter];
-        if (mappedPhase === undefined) {
+        const isOn = this.detectionOnCodes.has(record.eventCode);
+        const isOff = this.detectorOffCodes.has(record.eventCode);
+
+        if (!isOn && !isOff) {
           return;
         }
 
-        if (!eventsByPhase.has(mappedPhase)) {
-          eventsByPhase.set(mappedPhase, []);
+        if (mappedPhase === undefined) {
+          this.unmappedDetectorEvents += 1;
+          return;
         }
 
-        eventsByPhase.get(mappedPhase).push(record.timestampMs);
+        const binIndex = bins.findIndex(
+          (bin) => record.timestampMs >= bin.startMs && record.timestampMs < bin.endMs,
+        );
+
+        if (isOn) {
+          if (binIndex >= 0) {
+            const binMetrics = ensurePhaseBin(mappedPhase, binIndex);
+            binMetrics.activationCount += 1;
+          }
+          openOnByChannel.set(record.parameter, {
+            startMs: record.timestampMs,
+            phase: mappedPhase,
+          });
+          return;
+        }
+
+        if (isOff) {
+          const open = openOnByChannel.get(record.parameter);
+          if (!open) {
+            return;
+          }
+          addOccupancySpan(open.phase, open.startMs, record.timestampMs);
+          openOnByChannel.delete(record.parameter);
+        }
       });
 
-      eventsByPhase.forEach((timestamps) => timestamps.sort((a, b) => a - b));
-      return eventsByPhase;
+      const fallbackEndMs = bins[bins.length - 1]?.endMs;
+      openOnByChannel.forEach((open) => {
+        if (fallbackEndMs !== undefined) {
+          addOccupancySpan(open.phase, open.startMs, fallbackEndMs);
+        }
+      });
+
+      return metricsByPhase;
+    },
+    buildTerminationCounts(records, bins) {
+      const countsByPhase = new Map();
+      const ensurePhaseBin = (phase, binIndex) => {
+        if (!countsByPhase.has(phase)) {
+          countsByPhase.set(phase, []);
+        }
+        const phaseBins = countsByPhase.get(phase);
+        if (!phaseBins[binIndex]) {
+          phaseBins[binIndex] = {
+            gapOutCount: 0,
+            maxOutCount: 0,
+          };
+        }
+        return phaseBins[binIndex];
+      };
+
+      records.forEach((record) => {
+        const isGapOut = this.gapOutCodes.has(record.eventCode);
+        const isMaxOut = this.maxOutCodes.has(record.eventCode);
+        if (!isGapOut && !isMaxOut) {
+          return;
+        }
+
+        const phase = record.parameter;
+        const binIndex = bins.findIndex(
+          (bin) => record.timestampMs >= bin.startMs && record.timestampMs < bin.endMs,
+        );
+        if (binIndex < 0) {
+          return;
+        }
+
+        const counts = ensurePhaseBin(phase, binIndex);
+        if (isGapOut) {
+          counts.gapOutCount += 1;
+        }
+        if (isMaxOut) {
+          counts.maxOutCount += 1;
+        }
+      });
+
+      return countsByPhase;
+    },
+    buildRowsByBin(bins, phaseIntervalsByPhase, detectorMetricsByPhase, terminationCountsByPhase) {
+      const phaseSet = new Set([
+        ...phaseIntervalsByPhase.keys(),
+        ...detectorMetricsByPhase.keys(),
+        ...terminationCountsByPhase.keys(),
+      ]);
+      const serviceFloor = Math.max(0, Number(this.minServiceSeconds) || 0);
+      const rows = [];
+
+      [...phaseSet].forEach((phase) => {
+        const intervals = phaseIntervalsByPhase.get(phase) || [];
+        bins.forEach((bin, binIndex) => {
+          const detectorMetrics = detectorMetricsByPhase.get(phase)?.[binIndex] || {
+            activationCount: 0,
+            occupancySeconds: 0,
+          };
+          const terminationCounts = terminationCountsByPhase.get(phase)?.[binIndex] || {
+            gapOutCount: 0,
+            maxOutCount: 0,
+          };
+
+          const serviceSeconds = intervals.reduce((sum, interval) => {
+            const overlapMs = Math.max(
+              0,
+              Math.min(interval.endMs, bin.endMs) - Math.max(interval.startMs, bin.startMs),
+            );
+            return sum + overlapMs / 1000;
+          }, 0);
+
+          const demandProxy = detectorMetrics.activationCount + detectorMetrics.occupancySeconds / 10;
+          const safeServiceSeconds = Math.max(serviceFloor, serviceSeconds);
+          const pressure = safeServiceSeconds > 0 ? demandProxy / safeServiceSeconds : 0;
+
+          rows.push({
+            phase,
+            cycleNumber: binIndex + 1,
+            binStartLabel: bin.startTime,
+            binEndLabel: bin.endTime,
+            activationCount: detectorMetrics.activationCount,
+            occupancySeconds: detectorMetrics.occupancySeconds,
+            demandProxy,
+            serviceSeconds,
+            safeServiceSeconds,
+            pressure,
+            gapOutCount: terminationCounts.gapOutCount,
+            maxOutCount: terminationCounts.maxOutCount,
+          });
+        });
+      });
+
+      return rows;
     },
     getCellPressure(row, phase) {
       return row.byPhase?.[phase]?.pressure ?? null;
@@ -401,9 +587,14 @@ export default {
       }
 
       return [
-        `Phase ${phase} - Cycle ${row.cycleNumber}`,
-        `Demand (detector ON count): ${cell.demandCount}`,
+        `Phase ${phase} - Bin ${row.cycleNumber} (${cell.binStartLabel} - ${cell.binEndLabel})`,
+        `Demand activations: ${cell.activationCount}`,
+        `Demand occupancy (s): ${cell.occupancySeconds.toFixed(2)}`,
+        `Demand proxy: ${cell.demandProxy.toFixed(2)} (activations + occupancy/10)`,
         `Service (seconds): ${cell.serviceSeconds.toFixed(2)}`,
+        `Normalized service floor (seconds): ${cell.safeServiceSeconds.toFixed(2)}`,
+        `Gap-outs: ${cell.gapOutCount}`,
+        `Max-outs: ${cell.maxOutCount}`,
         `Pressure (demand/service): ${cell.pressure.toFixed(3)}`,
       ].join("\n");
     },


### PR DESCRIPTION
### Motivation
- Provide a time-bucketed pressure view (configurable minutes) so pressure can be analyzed across consistent intervals rather than per-cycle windows.
- Use richer detector signals (ON/OFF and occupancy spans) and termination events (gap-out / max-out) to produce a more robust demand/service proxy and surface termination causes.
- Improve transparency and auditability by exposing the components used to compute pressure for each cell and harden handling of partial/missing events and unmapped channels.

### Description
- Reworked `src/components/PhasePressureMapTool.vue` to compute time bins and to drive all downstream metrics from bins instead of service cycles, and added a `Bin size (minutes)` input and unmapped-event notice.
- Added descriptor-based lookups for detector OFF, gap-out, and max-out codes (in addition to existing detector ON and phase begin/end codes) and used these sets to parse CSV events.
- Implemented `buildTimeBins`, `buildDetectorDemandMetrics`, `buildTerminationCounts`, and `buildRowsByBin` to compute per-phase/per-bin activation counts, occupancy seconds, service overlap seconds, termination counts, a demand proxy (activations + occupancy/10), and a normalized pressure score with a configurable service floor to avoid divide-by-zero.
- Expanded cell tooltip contents to include bin bounds, activation count, occupancy seconds, demand proxy formula, service seconds, normalized service floor, gap-outs, max-outs, and final pressure so users can audit each cell's components.

### Testing
- Ran unit/integration tests with `npm run test`, which completed successfully (all tests passed).
- Verified production build with `npm run build`, which completed successfully (Vite build finished).
- Launched the dev server and captured an automated screenshot of the updated `/phase-pressure-map` UI to validate layout and labels.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a9193e8110832ba92da49c66353de3)