### PR TITLE
Hide zero-duration points in phase bubble plot

### DIFF
--- a/src/views/PhaseBubblePlot.vue
+++ b/src/views/PhaseBubblePlot.vue
@@ -181,8 +181,11 @@ export default {
         phaseColors.set(row.phase, palette[index % palette.length]);
       });
       const bubbleScale = 1.4;
+      const rowsWithDuration = this.displayedPhaseAggregates.filter(
+        (row) => Number(row.avgSplitServed) > 0,
+      );
       return {
-        datasets: this.displayedPhaseAggregates.map((row) => {
+        datasets: rowsWithDuration.map((row) => {
           const radius = Math.max(
             4,
             Math.sqrt(Number(row.avgSplitServed) || 0) * bubbleScale,


### PR DESCRIPTION
### Motivation
- Prevent phases with zero duration from rendering a visible bubble on the Phase Bubble Plot when `avgSplitServed` is `0` to avoid showing misleading dots.

### Description
- Filtered the dataset creation in `bubbleChartData` within `src/views/PhaseBubblePlot.vue` to only include rows where `Number(row.avgSplitServed) > 0` before mapping to chart datasets.

### Testing
- Ran the test suite with `npm test` and all tests passed (8/8).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b41659e460832b86133164d8ddab00)