### PR TITLE
Add fullscreen buttons for dashboard and high-res explainer tables

### DIFF
--- a/src/components/CSVInput.vue
+++ b/src/components/CSVInput.vue
@@ -26,15 +26,27 @@
               <div class="table-count">
                 Rows in table: {{ filteredRows.length }}
               </div>
-              <v-btn
-                color="secondary"
-                :disabled="!rowData.length"
-                @click="exportToExcel"
-              >
-                Export to Excel
-              </v-btn>
+              <div class="table-actions">
+                <v-btn
+                  color="secondary"
+                  :disabled="!rowData.length"
+                  @click="exportToExcel"
+                >
+                  Export to Excel
+                </v-btn>
+                <v-btn
+                  variant="text"
+                  :icon="isTableFullscreen ? 'mdi-fullscreen-exit' : 'mdi-fullscreen'"
+                  :aria-label="
+                    isTableFullscreen
+                      ? 'Exit full screen view'
+                      : 'View explainer table in full screen'
+                  "
+                  @click="toggleTableFullscreen"
+                ></v-btn>
+              </div>
             </div>
-            <div class="virtual-table">
+            <div ref="virtualTable" class="virtual-table">
               <div class="virtual-table__filters">
                 <input
                   type="text"
@@ -109,6 +121,7 @@ export default {
       },
       rowData: [],
       isProcessing: false,
+      isTableFullscreen: false,
       timezoneOffset: "America/Los_Angeles",
       usaTimezones: {
         "America/New_York": -5, // UTC offset: -5 hours
@@ -327,6 +340,22 @@ export default {
         }
       });
     },
+    async toggleTableFullscreen() {
+      const tableEl = this.$refs.virtualTable;
+      if (!tableEl) {
+        return;
+      }
+
+      if (document.fullscreenElement === tableEl) {
+        await document.exitFullscreen();
+        return;
+      }
+
+      await tableEl.requestFullscreen();
+    },
+    handleFullscreenChange() {
+      this.isTableFullscreen = document.fullscreenElement === this.$refs.virtualTable;
+    },
     highlightMatches(text, filterValue) {
       if (filterValue === "" || filterValue === null || filterValue === undefined) {
         return text;
@@ -408,9 +437,13 @@ export default {
     },
   },
   mounted() {
+    document.addEventListener("fullscreenchange", this.handleFullscreenChange);
     // Output the processed data when the component is mounted
     //const output = this.processTimeSeriesData();
     //document.querySelector('timeseries').innerHTML = output;
+  },
+  beforeUnmount() {
+    document.removeEventListener("fullscreenchange", this.handleFullscreenChange);
   },
 };
 </script>
@@ -453,6 +486,21 @@ export default {
   border: 1px solid #d0d0d0;
   border-radius: 4px;
   overflow: hidden;
+}
+
+.virtual-table:fullscreen {
+  border: none;
+  border-radius: 0;
+  width: 100%;
+  height: 100vh;
+  background: #fff;
+  display: flex;
+  flex-direction: column;
+}
+
+.virtual-table:fullscreen .virtual-table__body {
+  flex: 1;
+  max-height: none;
 }
 
 .virtual-table__header,
@@ -551,6 +599,11 @@ select {
   justify-content: space-between;
   gap: 12px;
   margin-bottom: 12px;
+}
+.table-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
 }
 .table-count {
   font-weight: 600;

--- a/src/views/Dashboard.vue
+++ b/src/views/Dashboard.vue
@@ -143,9 +143,22 @@
       </div>
 
       <v-card class="tool-card" variant="outlined">
-        <v-card-title class="card-title">High Resolution Explainer Tool</v-card-title>
+        <v-card-title class="card-title card-title--actions">
+          <span>High Resolution Explainer Tool</span>
+          <v-btn
+            size="small"
+            variant="text"
+            :icon="isExplainerFullscreen ? 'mdi-fullscreen-exit' : 'mdi-fullscreen'"
+            :aria-label="
+              isExplainerFullscreen
+                ? 'Exit full screen view'
+                : 'View explainer table in full screen'
+            "
+            @click="toggleExplainerFullscreen"
+          ></v-btn>
+        </v-card-title>
         <v-card-text class="card-body">
-          <div class="explainer-table">
+          <div ref="explainerTable" class="explainer-table">
             <v-table density="compact">
             <thead>
               <tr>
@@ -259,6 +272,7 @@ export default {
         parameter: "",
         description: "",
       },
+      isExplainerFullscreen: false,
     };
   },
   computed: {
@@ -363,6 +377,22 @@ export default {
   methods: {
     updateSplitHistory(data) {
       this.splitHistoryRows = data;
+    },
+    async toggleExplainerFullscreen() {
+      const explainerEl = this.$refs.explainerTable;
+      if (!explainerEl) {
+        return;
+      }
+
+      if (document.fullscreenElement === explainerEl) {
+        await document.exitFullscreen();
+        return;
+      }
+
+      await explainerEl.requestFullscreen();
+    },
+    handleFullscreenChange() {
+      this.isExplainerFullscreen = document.fullscreenElement === this.$refs.explainerTable;
     },
     processDashboard() {
       const lines = this.inputData.split("\n");
@@ -509,6 +539,12 @@ export default {
       return parts[3] || "";
     },
   },
+  mounted() {
+    document.addEventListener("fullscreenchange", this.handleFullscreenChange);
+  },
+  beforeUnmount() {
+    document.removeEventListener("fullscreenchange", this.handleFullscreenChange);
+  },
 };
 </script>
 
@@ -560,6 +596,12 @@ export default {
 .card-title {
   font-size: 0.95rem;
   padding: 10px 14px 4px;
+}
+
+.card-title--actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
 }
 
 .card-body {
@@ -673,6 +715,15 @@ export default {
   max-height: 300px;
   overflow: auto;
   font-size: 0.8rem;
+}
+
+.explainer-table:fullscreen {
+  max-height: 100vh;
+  height: 100vh;
+  width: 100%;
+  background: #fff;
+  padding: 8px;
+  box-sizing: border-box;
 }
 
 .explainer-table thead tr:first-child th {


### PR DESCRIPTION
### Motivation

- The enumeration tables on the Signal Dashboard and the High Resolution Data Explainer are often large and require more screen real estate to review and scroll comfortably. 
- Provide quick fullscreen toggles so users can expand those tables to use the browser viewport for easier inspection of enumeration events.

### Description

- Added a fullscreen toggle button and UI state to the Dashboard High Resolution Explainer card, wired to the browser Fullscreen API and tracked with `isExplainerFullscreen` and a `fullscreenchange` listener. 
- Exposed the explainer table container via `ref="explainerTable"` and implemented `toggleExplainerFullscreen` and `handleFullscreenChange` methods in `src/views/Dashboard.vue`, plus fullscreen-specific CSS (`.explainer-table:fullscreen`) to expand the container. 
- Added a fullscreen toggle button to the High Resolution Data Explainer toolbar in `src/components/CSVInput.vue`, exposed the virtual table via `ref="virtualTable"`, implemented `toggleTableFullscreen` and `handleFullscreenChange`, and added `isTableFullscreen` state and fullscreen CSS rules for `.virtual-table:fullscreen` and its body. 
- Registered and removed `fullscreenchange` listeners in `mounted` / `beforeUnmount` for both components and updated card title styling to accommodate the action button.

### Testing

- Ran `npm run build` and the production build completed successfully. 
- Ran `npm test` and the automated test suite passed (`1..8`, all tests passed). 
- Attempted an automated Playwright screenshot run to visually validate the new buttons, but the local dev server was not reachable in this environment and the Playwright script failed with a connection error (`ERR_EMPTY_RESPONSE` / connection refused).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4ed1d93b0832bb3fb6b80b26185bb)