### PR TITLE
Add feature-based GeoJSON map styling

### DIFF
--- a/src/components/ProcessGeoJSONMapper.vue
+++ b/src/components/ProcessGeoJSONMapper.vue
@@ -74,6 +74,20 @@
       </v-col>
     </v-row>
 
+    <v-alert
+      v-if="layers.length"
+      type="info"
+      variant="tonal"
+      class="mb-4"
+    >
+      Feature-level styling is supported from GeoJSON properties. Use
+      <code>stroke</code>, <code>color</code>, <code>lineColor</code>,
+      <code>fill</code>, <code>marker-color</code>, <code>marker-size</code>,
+      <code>radius</code>, or a nested <code>style</code> object to give
+      different features different colors and point sizes inside the same
+      GeoJSON file.
+    </v-alert>
+
     <div ref="mapWrapper" class="map-wrapper">
       <l-map ref="mapRef" :zoom="zoom" :center="center" class="leaflet-map">
         <l-tile-layer :url="tileUrl" :attribution="attribution" />
@@ -252,16 +266,159 @@ export default {
     isValidGeoJson(geoJson) {
       return !!(geoJson && geoJson.type);
     },
-    layerStyle(layer) {
+    normalizeFeatureProperties(feature) {
+      if (!feature || typeof feature !== "object") {
+        return {};
+      }
+
+      const properties =
+        feature.type === "Feature" && feature.properties && typeof feature.properties === "object"
+          ? feature.properties
+          : {};
+      const nestedStyle =
+        properties.style && typeof properties.style === "object" ? properties.style : {};
+
       return {
-        color: layer.color,
-        weight: layer.weight,
-        fillColor: layer.color,
-        fillOpacity: 0.25,
+        ...properties,
+        ...nestedStyle,
       };
+    },
+    firstDefinedValue(values) {
+      return values.find(
+        (value) =>
+          value !== undefined &&
+          value !== null &&
+          !(typeof value === "string" && value.trim() === "")
+      );
+    },
+    normalizeColor(value, fallback) {
+      if (typeof value !== "string") {
+        return fallback;
+      }
+
+      const trimmed = value.trim();
+      return trimmed || fallback;
+    },
+    normalizeNumber(value, fallback, minimum = 0) {
+      const numeric = Number(value);
+      if (!Number.isFinite(numeric)) {
+        return fallback;
+      }
+      return Math.max(minimum, numeric);
+    },
+    normalizeOpacity(value, fallback) {
+      const numeric = Number(value);
+      if (!Number.isFinite(numeric)) {
+        return fallback;
+      }
+      return Math.min(1, Math.max(0, numeric));
+    },
+    pointRadiusFromSize(size, fallback) {
+      if (typeof size !== "string") {
+        return fallback;
+      }
+
+      const normalized = size.trim().toLowerCase();
+      if (normalized === "small") {
+        return 4;
+      }
+      if (normalized === "medium") {
+        return 7;
+      }
+      if (normalized === "large") {
+        return 10;
+      }
+      return fallback;
+    },
+    getFeatureStyle(layer, feature) {
+      const properties = this.normalizeFeatureProperties(feature);
+      const strokeColor = this.normalizeColor(
+        this.firstDefinedValue([
+          properties.stroke,
+          properties.lineColor,
+          properties.line_color,
+          properties.color,
+          properties.outlineColor,
+          properties.outline_color,
+        ]),
+        layer.color
+      );
+      const fillColor = this.normalizeColor(
+        this.firstDefinedValue([
+          properties.fill,
+          properties.fillColor,
+          properties.fill_color,
+          properties["marker-color"],
+          properties.markerColor,
+          properties.marker_color,
+          strokeColor,
+        ]),
+        strokeColor
+      );
+
+      return {
+        color: strokeColor,
+        weight: this.normalizeNumber(
+          this.firstDefinedValue([
+            properties["stroke-width"],
+            properties.strokeWidth,
+            properties.weight,
+          ]),
+          layer.weight,
+          1
+        ),
+        opacity: this.normalizeOpacity(
+          this.firstDefinedValue([
+            properties["stroke-opacity"],
+            properties.strokeOpacity,
+            properties.opacity,
+          ]),
+          1
+        ),
+        fillColor,
+        fillOpacity: this.normalizeOpacity(
+          this.firstDefinedValue([
+            properties["fill-opacity"],
+            properties.fillOpacity,
+          ]),
+          0.25
+        ),
+      };
+    },
+    getPointStyle(layer, feature) {
+      const featureStyle = this.getFeatureStyle(layer, feature);
+      const properties = this.normalizeFeatureProperties(feature);
+      const fallbackRadius = 7;
+
+      return {
+        ...featureStyle,
+        radius: this.normalizeNumber(
+          this.firstDefinedValue([
+            properties.radius,
+            properties.pointRadius,
+            properties.point_radius,
+            this.pointRadiusFromSize(
+              this.firstDefinedValue([
+                properties["marker-size"],
+                properties.markerSize,
+              ]),
+              fallbackRadius
+            ),
+          ]),
+          fallbackRadius,
+          1
+        ),
+      };
+    },
+    layerStyle(layer) {
+      return (feature) => this.getFeatureStyle(layer, feature);
     },
     layerOptions(layer) {
       return {
+        pointToLayer: (feature, latLng) => {
+          const pointStyle = this.getPointStyle(layer, feature);
+          return L.circleMarker(latLng, pointStyle);
+        },
         onEachFeature: (feature, leafletLayer) => {
           leafletLayer.on("click", (event) => {
             this.selectLayer(layer.id);


### PR DESCRIPTION
### Motivation

- Allow GeoJSON features to override layer defaults so lines, polygons, and point markers can have per-feature colors, weights, and sizes without creating separate layers.
- Support multiple colors and point sizes within a single uploaded GeoJSON file to make the mapper suitable for multi-class datasets.

### Description

- Added UI hint explaining supported per-feature properties such as `stroke`, `color`, `lineColor`, `fill`, `marker-color`, `marker-size`, `radius`, and a nested `style` object in `ProcessGeoJSONMapper.vue`.
- Replaced the previous single layer-wide style with a feature-aware style function by changing `layerStyle` to return a function that calls `getFeatureStyle(layer, feature)`.
- Implemented property normalization and helpers: `normalizeFeatureProperties`, `firstDefinedValue`, `normalizeColor`, `normalizeNumber`, `normalizeOpacity`, and `pointRadiusFromSize` to robustly read styling values from feature properties.
- Render GeoJSON points as `L.circleMarker` via `pointToLayer` with `getPointStyle` so per-feature radii and colors are applied, while still falling back to layer defaults.

### Testing

- Ran `npm test` and all existing tests passed (`8` tests, `0` failures).
- Ran `npm run build` and the production build completed successfully (Vite build finished without errors).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bac67651e4832bb074f1a5871cef0a)