### PR TITLE
Add Coordination Learning Tool — interactive signal coordination simulator

### DIFF
--- a/src/router/index.js
+++ b/src/router/index.js
@@ -48,6 +48,7 @@ import DetectorBubbleChart from '../views/DetectorBubbleChart'
 import PhaseBubbleScatter from '../views/PhaseBubbleScatter'
 import BlockLogic from '../views/BlockLogic'
 import GeoJSONMapper from '../views/GeoJSONMapper'
+import CoordinationLearningTool from '../views/CoordinationLearningTool'
 
 
 
@@ -272,6 +273,11 @@ const routes = [
         path: '/phase-bubble-scatter',
         name: 'phaseBubbleScatter',
         component: PhaseBubbleScatter,
+    },
+    {
+        path: '/coordination-learning-tool',
+        name: 'coordinationLearningTool',
+        component: CoordinationLearningTool,
     },
     {
         path: '/tools/block-logic',

--- a/src/seo/routes.js
+++ b/src/seo/routes.js
@@ -193,6 +193,12 @@ export const routeMeta = {
       "Identify detector on events where the assigned phase is not served within two minutes.",
     path: "/skipped-phase-finder",
   },
+  coordinationLearningTool: {
+    title: "Traffic Signal Coordination Learning Tool | Cycle, Splits & Offsets",
+    description:
+      "Use interactive sliders and visuals to learn cycle length, split times, offsets, scheduler plans, and coordinated green phases across multiple signals.",
+    path: "/coordination-learning-tool",
+  },
   signalOffsets: {
     title: "Signal Offset Calculator | Coordinated Phase Alignment",
     description:

--- a/src/views/CoordinationLearningTool.vue
+++ b/src/views/CoordinationLearningTool.vue
@@ -1,0 +1,237 @@
+<template>
+  <main class="coordination-tool">
+    <section class="hero-panel">
+      <div>
+        <p class="eyebrow">Interactive signal timing lab</p>
+        <h1>Traffic Signal Coordination Learning Tool</h1>
+        <p class="hero-copy">
+          Adjust cycle length, split times, offsets, scheduler start time, and coordinated phases to see how multiple signals align their green bands along a corridor.
+        </p>
+      </div>
+      <div class="hero-stat">
+        <strong>{{ progressionBandwidth }}s</strong>
+        <span>continuous green band</span>
+      </div>
+    </section>
+
+    <v-container fluid class="tool-grid">
+      <v-row>
+        <v-col cols="12" lg="4">
+          <v-card class="control-card" variant="outlined">
+            <v-card-title>Timing controls</v-card-title>
+            <v-card-text>
+              <div class="control-group">
+                <label>Cycle length: {{ cycleLength }} seconds</label>
+                <v-slider v-model="cycleLength" :min="60" :max="150" :step="5" color="primary" thumb-label></v-slider>
+              </div>
+              <div class="control-group">
+                <label>Coordinated phase split: {{ coordinatedSplit }} seconds</label>
+                <v-slider v-model="coordinatedSplit" :min="20" :max="maxCoordinatedSplit" :step="5" color="green" thumb-label></v-slider>
+              </div>
+              <div class="control-group">
+                <label>Side-street split: {{ sideStreetSplit }} seconds</label>
+                <v-slider v-model="sideStreetSplit" :min="10" :max="maxSideStreetSplit" :step="5" color="orange" thumb-label></v-slider>
+              </div>
+              <div class="control-group">
+                <label>Scheduler time of day: {{ formattedClock }}</label>
+                <v-slider v-model="schedulerMinute" :min="0" :max="1439" :step="15" color="indigo" thumb-label></v-slider>
+              </div>
+              <v-select
+                v-model="coordinatedPhase"
+                :items="phaseOptions"
+                label="Coordinated movement"
+                variant="outlined"
+                density="compact"
+              ></v-select>
+              <v-switch v-model="showVehicles" color="primary" label="Show progression vehicles"></v-switch>
+            </v-card-text>
+          </v-card>
+
+          <v-card class="control-card concept-card" variant="outlined">
+            <v-card-title>Concept legend</v-card-title>
+            <v-card-text>
+              <div v-for="item in conceptLegend" :key="item.term" class="concept-row">
+                <span class="legend-dot" :style="{ background: item.color }"></span>
+                <div><strong>{{ item.term }}</strong><p>{{ item.description }}</p></div>
+              </div>
+            </v-card-text>
+          </v-card>
+        </v-col>
+
+        <v-col cols="12" lg="8">
+          <v-card class="visual-card" variant="outlined">
+            <v-card-title class="visual-title">
+              <span>Coordinated corridor timeline</span>
+              <v-chip color="green" variant="tonal">{{ coordinationQuality }}</v-chip>
+            </v-card-title>
+            <v-card-text>
+              <div class="timeline-axis">
+                <span v-for="tick in timelineTicks" :key="tick">{{ tick }}s</span>
+              </div>
+              <div class="signal-row" v-for="signal in signals" :key="signal.name">
+                <div class="signal-label">
+                  <strong>{{ signal.name }}</strong>
+                  <small>{{ signal.distance }} ft · offset {{ signal.offset }}s</small>
+                  <v-slider v-model="signal.offset" :min="0" :max="cycleLength - 1" :step="1" color="blue" density="compact" hide-details thumb-label></v-slider>
+                </div>
+                <div class="cycle-track">
+                  <div class="offset-marker" :style="{ left: percent(signal.offset) + '%' }">offset</div>
+                  <div
+                    v-for="band in getBands(signal)"
+                    :key="`${signal.name}-${band.start}-${band.color}`"
+                    class="phase-band"
+                    :class="band.color"
+                    :style="{ left: percent(band.start) + '%', width: percent(band.duration) + '%' }"
+                  >{{ band.label }}</div>
+                </div>
+              </div>
+              <div class="progression-window" :style="progressionStyle">
+                coordinated green window
+              </div>
+            </v-card-text>
+          </v-card>
+
+          <v-card class="visual-card corridor-card" variant="outlined">
+            <v-card-title>Street view progression</v-card-title>
+            <v-card-text>
+              <div class="corridor">
+                <div class="road-line"></div>
+                <div
+                  v-for="signal in signals"
+                  :key="signal.name"
+                  class="signal-mast"
+                  :style="{ left: signal.position + '%' }"
+                >
+                  <div class="signal-head" :class="isGreen(signal) ? 'go' : 'stop'"></div>
+                  <span>{{ signal.name }}</span>
+                </div>
+                <div v-if="showVehicles" class="vehicle-platoon" :style="vehicleStyle">🚗 🚙 🚕</div>
+              </div>
+              <p class="insight-text">{{ insightText }}</p>
+            </v-card-text>
+          </v-card>
+        </v-col>
+      </v-row>
+    </v-container>
+  </main>
+</template>
+
+<script>
+export default {
+  name: "CoordinationLearningTool",
+  data() {
+    return {
+      cycleLength: 100,
+      coordinatedSplit: 45,
+      sideStreetSplit: 25,
+      schedulerMinute: 480,
+      coordinatedPhase: "Main Street through phases 2 + 6",
+      showVehicles: true,
+      phaseOptions: ["Main Street through phases 2 + 6", "Cross street phases 4 + 8"],
+      signals: [
+        { name: "Signal A", distance: 0, offset: 0, position: 8 },
+        { name: "Signal B", distance: 900, offset: 8, position: 38 },
+        { name: "Signal C", distance: 1800, offset: 16, position: 68 },
+        { name: "Signal D", distance: 2600, offset: 24, position: 90 },
+      ],
+    };
+  },
+  computed: {
+    maxCoordinatedSplit() { return this.cycleLength - 20; },
+    maxSideStreetSplit() { return this.cycleLength - this.coordinatedSplit - 5; },
+    clearanceTime() { return Math.max(5, this.cycleLength - this.coordinatedSplit - this.sideStreetSplit); },
+    formattedClock() {
+      const hours = Math.floor(this.schedulerMinute / 60).toString().padStart(2, "0");
+      const minutes = (this.schedulerMinute % 60).toString().padStart(2, "0");
+      return `${hours}:${minutes}`;
+    },
+    timelineTicks() { return [0, Math.round(this.cycleLength / 4), Math.round(this.cycleLength / 2), Math.round(this.cycleLength * 0.75), this.cycleLength]; },
+    progressionBandwidth() {
+      const starts = this.signals.map((signal) => signal.offset);
+      const ends = starts.map((start) => start + this.coordinatedSplit);
+      return Math.max(0, Math.min(...ends) - Math.max(...starts));
+    },
+    coordinationQuality() {
+      if (this.progressionBandwidth >= 20) return "Strong progression";
+      if (this.progressionBandwidth >= 10) return "Partial progression";
+      return "Adjust offsets";
+    },
+    progressionStyle() {
+      const start = Math.max(...this.signals.map((signal) => signal.offset));
+      return { left: this.percent(start) + "%", width: this.percent(this.progressionBandwidth) + "%" };
+    },
+    vehicleStyle() {
+      const start = Math.max(...this.signals.map((signal) => signal.offset));
+      return { left: `${Math.min(88, 6 + (start / this.cycleLength) * 70)}%` };
+    },
+    insightText() {
+      return `At ${this.formattedClock}, the scheduler runs a ${this.cycleLength}s cycle. ${this.coordinatedPhase} receives ${this.coordinatedSplit}s of green; offsets shift each downstream green start so a platoon can arrive during the shared ${this.progressionBandwidth}s window.`;
+    },
+    conceptLegend() {
+      return [
+        { term: "Cycle length", color: "#263238", description: "One complete repeat of all signal indications." },
+        { term: "Split time", color: "#43a047", description: "Seconds assigned to a phase within the cycle." },
+        { term: "Offset", color: "#1e88e5", description: "Time shift from the master clock to the coordinated green." },
+        { term: "Scheduler", color: "#5e35b1", description: "Time-of-day plan that selects cycle, splits, and offsets." },
+      ];
+    },
+  },
+  watch: {
+    cycleLength() {
+      this.signals.forEach((signal) => { signal.offset = Math.min(signal.offset, this.cycleLength - 1); });
+      this.coordinatedSplit = Math.min(this.coordinatedSplit, this.maxCoordinatedSplit);
+      this.sideStreetSplit = Math.min(this.sideStreetSplit, this.maxSideStreetSplit);
+    },
+  },
+  methods: {
+    percent(value) { return (value / this.cycleLength) * 100; },
+    getBands(signal) {
+      return [
+        { start: signal.offset, duration: this.coordinatedSplit, color: "green", label: "coordinated green" },
+        { start: signal.offset + this.coordinatedSplit, duration: this.clearanceTime, color: "yellow", label: "change" },
+        { start: signal.offset + this.coordinatedSplit + this.clearanceTime, duration: this.sideStreetSplit, color: "red", label: "side street" },
+      ].filter((band) => band.start < this.cycleLength).map((band) => ({ ...band, duration: Math.min(band.duration, this.cycleLength - band.start) }));
+    },
+    isGreen(signal) {
+      const currentSecond = this.schedulerMinute % this.cycleLength;
+      return currentSecond >= signal.offset && currentSecond <= signal.offset + this.coordinatedSplit;
+    },
+  },
+};
+</script>
+
+<style scoped>
+.coordination-tool { padding: 20px; background: linear-gradient(180deg, #f5fbff 0%, #ffffff 48%); }
+.hero-panel { display: flex; justify-content: space-between; gap: 24px; max-width: 1180px; margin: 0 auto 18px; padding: 28px; border-radius: 24px; background: #0f2f3f; color: white; }
+.eyebrow { color: #9be7c7; font-weight: 700; text-transform: uppercase; letter-spacing: .08em; }
+h1 { font-size: clamp(2rem, 4vw, 3.6rem); line-height: 1.05; margin: 0 0 12px; }
+.hero-copy { max-width: 760px; font-size: 1.1rem; line-height: 1.55; }
+.hero-stat { min-width: 180px; display: grid; place-items: center; text-align: center; border: 1px solid rgba(255,255,255,.25); border-radius: 18px; padding: 16px; }
+.hero-stat strong { font-size: 2.7rem; color: #72e08f; }
+.tool-grid { max-width: 1220px; }
+.control-card, .visual-card { border-radius: 18px; margin-bottom: 18px; background: rgba(255,255,255,.94); }
+.control-group label { display: block; font-weight: 700; margin: 14px 0 0; color: #244050; }
+.concept-row { display: flex; gap: 12px; margin-bottom: 14px; }
+.concept-row p { margin: 2px 0 0; color: #52636e; line-height: 1.35; }
+.legend-dot { width: 14px; height: 14px; border-radius: 50%; margin-top: 5px; flex: 0 0 auto; }
+.visual-title { display: flex; justify-content: space-between; align-items: center; gap: 12px; }
+.timeline-axis { display: flex; justify-content: space-between; color: #607d8b; font-size: .85rem; padding-left: 158px; margin-bottom: 8px; }
+.signal-row { display: grid; grid-template-columns: 150px 1fr; gap: 12px; align-items: center; margin: 18px 0; }
+.signal-label small { display: block; color: #607d8b; }
+.cycle-track { position: relative; height: 58px; background: repeating-linear-gradient(90deg, #edf3f7 0, #edf3f7 12px, #f8fbfd 12px, #f8fbfd 24px); border-radius: 12px; overflow: hidden; border: 1px solid #d8e5ec; }
+.phase-band { position: absolute; top: 10px; height: 38px; color: white; font-size: .76rem; display: flex; align-items: center; justify-content: center; white-space: nowrap; }
+.phase-band.green { background: #2eaf5d; }
+.phase-band.yellow { background: #f9a825; color: #263238; }
+.phase-band.red { background: #d95c5c; }
+.offset-marker { position: absolute; z-index: 2; top: 0; bottom: 0; border-left: 3px solid #1e88e5; color: #1565c0; font-size: .7rem; padding-left: 4px; font-weight: 700; }
+.progression-window { position: relative; height: 30px; margin-left: 162px; border-radius: 999px; background: rgba(46, 175, 93, .18); border: 2px dashed #2eaf5d; color: #1b5e20; text-align: center; font-weight: 700; }
+.corridor { position: relative; height: 210px; border-radius: 18px; background: linear-gradient(#cfe8d4 0 38%, #4a4f55 38% 68%, #cfe8d4 68%); overflow: hidden; }
+.road-line { position: absolute; left: 4%; right: 4%; top: 52%; border-top: 5px dashed #f7e27a; }
+.signal-mast { position: absolute; top: 33%; transform: translateX(-50%); text-align: center; font-weight: 700; color: #17313f; }
+.signal-head { width: 34px; height: 34px; margin: 0 auto 58px; border-radius: 50%; border: 5px solid #263238; box-shadow: 0 0 0 5px #455a64; }
+.signal-head.go { background: #22c55e; }
+.signal-head.stop { background: #ef4444; }
+.vehicle-platoon { position: absolute; top: 47%; transform: translateX(-50%); font-size: 1.8rem; transition: left .25s ease; }
+.insight-text { margin: 14px 0 0; color: #37474f; line-height: 1.55; }
+@media (max-width: 760px) { .hero-panel { flex-direction: column; } .signal-row { grid-template-columns: 1fr; } .timeline-axis, .progression-window { margin-left: 0; padding-left: 0; } }
+</style>

--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -70,6 +70,15 @@ export default {
         },
         {
           image:
+            "https://trafficsignalkit.s3.us-east-2.amazonaws.com/Photos/TrafficSignalKit.com+-+Offset+Calculation.png",
+          title: "Coordination Learning Tool",
+          description:
+            "Interactive sliders and visuals for cycle length, splits, offsets, scheduler plans, and coordinated phases.",
+          link: "/coordination-learning-tool",
+          topics: ["Coordination", "Education", "Offsets"],
+        },
+        {
+          image:
             "https://trafficsignalkit.s3.us-east-2.amazonaws.com/Photos/TrafficSignalkit.com+-+Vehicle+and+Pedestrian+Delay.png",
           title: "Delay & Count Estimator",
           description: "Estimate detector call delays to phase service",


### PR DESCRIPTION
### Motivation
- Provide an interactive learning tool to teach traffic-signal coordination concepts like cycle length, split times, offsets, scheduler plans, and coordinated phases using sliders and clear visuals. 

### Description
- Add a new Vue view `src/views/CoordinationLearningTool.vue` that implements timing controls (cycle, coordinated split, side-street split, scheduler minute, coordinated movement), per-signal offset sliders, a corridor timeline visualization, a street-view progression preview, and a concept legend.  
- Compute progression metrics in the component (e.g. `progressionBandwidth`, `coordinationQuality`, `timelineTicks`, per-signal `getBands`) to render aligned green bands and a coordinated green window.  
- Register the new route `/coordination-learning-tool` in `src/router/index.js` and add SEO metadata for the route in `src/seo/routes.js`.  
- Add an entry card for the tool to the home page list in `src/views/Home.vue` so it appears in the site index. 

### Testing
- Built the production bundle with `npm run build`, which completed successfully.  
- Ran the unit test suite with `npm test` and all tests passed (`8` tests, `0` failures).  
- Ran `git diff --check` (whitespace / diff checks) with no reported issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7dd6572528832b8fdc5db93af51096)